### PR TITLE
:scroll: meetings: Add raw meeting minutes export, founding notes

### DIFF
--- a/meetings/founding-notes.md
+++ b/meetings/founding-notes.md
@@ -1,0 +1,859 @@
+Metalevel: Question: Process of defining our criteria and metrics. 
+
+  - A history on how we arrived at the different criteria?
+    
+      - > Comment Standards Needed to support this
+
+  - Capture existing works that states anything, and informs our work?
+
+  - Capture feedback in a systematic way.
+
+  - Reproducibility guidelines
+
+TODO: write in README.md our process and ways for 
+
+**Example of Project Place **- currently
+
+![](Pictures/100002010000038F000001A609AD36393A28D33E.png)
+
+New ***Detail page*** for each line e.g.: Documentation ---- specify how
+to answer the question.
+
+Documentation is codified knowledge. Documentation can be on the
+processes and practices of the community, thus empowering participants
+to contribute with certainty for how and why things are happening.
+Documentation can be on the artifacts produced by the community and as
+such empower participants to know where to contribute and what kind of
+contributions further the goals of the community.
+
+*Sample Objectives*:
+
+  - (Accessibility Screen Reader)Documentation is accessible according
+    to x standard for screen readers (which tool to use?)
+  - (Awareness) Documentation is findable
+  - (Clarity) Documentation is easy to follow and structured intuitively
+  - (Relevance) Documentation is regularly updated
+  - (Relevance) Environment builds are up to date
+  - (Non-Technical Accessibility) Documentation limits use of
+    unnecessary technical jargon
+  - (Information Amount) Documentation provides information so that
+    people gather as much information as they want, and no more than
+    they want
+  - (Learning by Doing) Documentation encourages hands-on learning, but
+    doesn’t require it
+  - (Learning by Process) Documentation provides not only details of
+    every step, but also how these steps fit together in the process
+  - (Inclusion) Documentation does not include non-inclusive language
+    (this could be ‘brogrammer’ language, or exclusionary/derogatory
+    language.
+  - (FOSS standards) README & CONTRIBUTING files provide intended
+    information
+
+*Sample Strategies*:
+
+  - A person goes through the documentation and checks off criteria
+    listed below.
+  - Gather feedback from new community members using below survey
+    questions.
+  - Include a quick survey (“was this page helpful”) at the bottom of
+    every page.
+  - Use the GenderMag Heuristics to evaluate the document’s
+    gender-inclusivity.
+    ([*http://gendermag.org/downloadables/GM-Heuristics-2018-0704.pdf*](http://gendermag.org/downloadables/GM-Heuristics-2018-0704.pdf)
+    )
+
+*Sample Metrics*: 
+
+**Qualitative
+
+  - > Is the documentation screen reader friendly? 
+    
+      - TODO: link to a tool that evaluates this. 
+      - TODO: provide an interpretation guide for the output of the
+        tool.
+
+  - > Gender-inclusivity:
+    
+      - TODO: what result will indicate good diversity and inclusion?
+        
+          - > “Score” on the GenderMag Heuristics (count of how many
+            > supported out of 5)
+        
+          - > “Score” on the “Sample Objective” list (count of how many
+            > supported out of the length of the list)
+
+  - > Interview with newcomers to find out how documentation helped (a)
+    > understand the contribution process and/or (b) help complete the
+    > task
+    
+      - TODO: write specific questions that can be asked of the newcomer
+      - TODO: provide an analysis method for the questions
+      - TODO: decide what kind of answers signal good diversity and
+        inclusion
+
+Quantitative
+
+  - > Quick bottom-page survey 
+    
+      - TODO: add specific questions 
+      - TODO: ways to analyze them.
+      - Check the wiki last-updated date (to satisfy recent/current)
+
+*Similar Resources*:
+
+  - 
+
+\--------------- ^^^ above meeting 6/20/2018
+
+<span id="anchor-166"></span>**Category: Diversity and Inclusion**
+
+Goal: Identify the diversity and inclusion within a project.
+
+<span id="anchor-167"></span>**Definitions**
+
+  - **Diversity**: How different are the people present?
+  - **Inclusion**: How well do we enable these different people to work
+    together?
+  - **Retention**: How long do different people stay engaged?
+  - **Attraction**: How well do we extend a hand to different newcomers?
+
+*Example 1:* Two people in a room. They can be diverse, but they don’t
+have to work together or be there still tomorrow. AND just because
+someone is there, doesn’t mean their experience is good.
+
+*Example 2:* Some minorities are not necessarily visible, do we want to
+measure their degree of visibility/outness? (e.g., disability,
+socio-economic, LGBTIQ, religion)
+
+*Example 3:* There may be women within a community that is less
+inclusive, but the women are determined to “see it through” and
+participate. In this case, retention does not necessarily reflect the
+level of inclusion within a community.
+
+I want to flag that we should have criteria / ethics /legal for each of
+these, and when they should be asked. (Intentionality of asking
+questions) . legal = asking PID + gender spectrum
+
+<span id="anchor-168"></span>**Dimensions of Demographics**
+
+1.  **Self-identified perceived-minority (what ever that means)**
+
+2.  Gender Identity
+    
+    1.  > Spectrum 
+    
+    2.  > Identify as transgender
+
+3.  Age / e.g., youths? 
+
+4.  Location/Region/Country
+
+5.  Access to Technology aka (sub for education)
+
+6.  Interest (Passion) 
+
+7.  Socio economic status
+
+8.  Tenure (time with project) / Tenure with the ecosystem
+
+9.  Race/Ethnicity
+
+10. First Language
+
+11. Confidence with English
+
+12. Disability
+
+13. Neurodiversity
+
+14. Sexual orientation
+
+15. Caregiver
+    
+    1.  > Parents with children
+    
+    2.  > Eldercare
+    
+    3.  > 
+
+The approach NumFOCUS has recently been taking is “Do you identify as a
+minority in the scientific computing community?” And if yes, then “along
+which dimensions?” and we give many of the types of options listed
+above, including “prefer not to say.”
+
+<span id="anchor-169"></span>**Event Diversity**
+
+Goal: Identify the diversity and inclusion at events.
+
+|                          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**                 | **Question**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Speaker Demographics     | What is the diversity of speakers? (overall and grouped by keynotes, sessions)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Attendees Demographics   | What is diversity of attendees? (for the event overall and grouped by sessions )                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Diversity Access Tickets | Are Diversity Access Tickets offered for an event?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Code of Conduct at Event | How does the Code of Conduct for events support diversity and inclusion? \[*(Note: we had these sub-bullet points and I think they should go on the detail page for this metric and overarching question, but until we create that page, we can keep them here) Is a Code of Conduct present for an event and visible? Is the Code of Conduct enforced? What is the sentiment towards the Code of conduct? Is the CoC trusted? Do people believe that the CoC is real? What is the readiness to report CoC violations? Are the steps known within minority groups? Do we see real differences in diversity and inclusion when we change the CoC?*\] |
+| Kid/Parent Friendliness  | Does the event host special activities for kids and youths? Mother’s room?childcare?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+
+Inclusive Design     quiet room, scent free, alcohol free 
+
+Good resource: <https://github.com/numfocus/discover-cookbook> 
+
+**Contributor Community **Goal: Identify the diversity of the
+contributors within a community.
+
+<table>
+<tbody>
+<tr class="odd">
+<td><strong>Name</strong></td>
+<td><strong>Question</strong></td>
+</tr>
+<tr class="even">
+<td>Collaboration Style</td>
+<td>How does the community collaborate?</td>
+</tr>
+<tr class="odd">
+<td>Basic metrics such as: code vs non-code, percentage of contributions, centrality or importance of the code contribution, emails, unbiased-code reviews, voting in the code review, etc.</td>
+<td><p>How diverse are the contributors across various ways of contributing? How many contributions come from diverse demographics?</p>
+<p>What is the trend of contributions from diverse demographics?</p>
+<p>We may need to split this into more questions</p></td>
+</tr>
+<tr class="even">
+<td>Measure how collaborative a community is (collaborative → inclusive)</td>
+<td>How inclusive is the community in integrating diverse contributors?</td>
+</tr>
+</tbody>
+</table>
+
+<span id="anchor-170"></span>**Communication **
+
+Goal: Identify how we are communicating with contributors, and potential
+contributors.
+
+|                                   |                                                                                    |
+| --------------------------------- | ---------------------------------------------------------------------------------- |
+| **Name**                          | **Question**                                                                       |
+| Listening                         | (how) Are we listening to communities?                                             |
+| Speaking                          | How are we speaking to communities?                                                |
+| Engaging Introverts               | How are we communicating with introverts?                                          |
+| Mode Alternatives                 | What alternative communication modes do we offer, e.g. text alternatives to video? |
+| Language Barriers                 | How are we communicating with non-English speakers?                                |
+| Speaking to specific demographics | How well do we specifically speak to individual demographics?                      |
+| Captioning                        | Do we provide text captioning for spoken communication?                            |
+| Technical Jargon                  | What barriers do we create by using technical jargon?                              |
+| Bandwidth                         | ???                                                                                |
+
+<span id="anchor-171"></span>**Recognition**
+
+Goal: Identify how we recognize/to reward good work in our community.
+
+<table>
+<tbody>
+<tr class="odd">
+<td><strong>Name</strong></td>
+<td><strong>Question</strong></td>
+</tr>
+<tr class="even">
+<td>Contribution Type Bias</td>
+<td>Do we have a bias to recognizing technical and code contributions or non-technical and non-code contributions more?</td>
+</tr>
+<tr class="odd">
+<td>Contribution Size Bias</td>
+<td><p>Do we have a bias towards small contributions or multiple contributions? How can we identify whether fewer quantities add qualitative value?</p>
+<p>How can we tell the quality of the contributions?</p>
+<p>First time contributions vs usual contributors</p></td>
+</tr>
+<tr class="even">
+<td></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+<span id="anchor-172"></span>**Leadership**
+
+Goal: Identify how healthy our community leadership is.
+
+Note: Leadership can be understood in different ways: formal roles,
+informal leaders, someone who volunteers exceptional leadership skills.
+→ the questions can be tailored to whatever your community cares about
+and can assess.
+
+<table>
+<tbody>
+<tr class="odd">
+<td><strong>Name</strong></td>
+<td><strong>Question</strong></td>
+</tr>
+<tr class="even">
+<td><p>Leadership Categories</p></td>
+<td>What are the leadership categories? (mentorship is one, there are more)</td>
+</tr>
+<tr class="odd">
+<td>Leadership Principles</td>
+<td>Does our leadership follow leadership principles?</td>
+</tr>
+<tr class="even">
+<td>Mentorship</td>
+<td>Do we have active mentorships and related activities?</td>
+</tr>
+</tbody>
+</table>
+
+<span id="anchor-173"></span>**Governance**
+
+Goal: Identify how diverse and inclusive our governance is.
+
+|                             |                                                                                                                                         |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**                    | **Question**                                                                                                                            |
+| Foundation Staff Diversity  | What is the diversity of foundation staff?                                                                                              |
+| Board/Council Diversity     | What is the diversity within our governing board or council?                                                                            |
+| Code of Conduct Presence    | Is our code of conduct visible and trusted?                                                                                             |
+| Code of Conduct Enforcement | How do community member perceive our enforcement of the code of conduct?                                                                |
+| Team Diversity              | What is the diversity of other bureaucratic and administrative foundation teams, e.g. working groups, committees, or ambassador groups? |
+| Path to Leadership          | What opportunities are there to move into governance? Are those pathways clear?                                                         |
+
+<span id="anchor-174"></span>**Project Places**
+
+Goal: Identify how diverse and inclusive our project places (e.g.,
+repositories, mailing lists, forum) are?
+
+|                                 |                                                                                                                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**                        | **Question**                                                                                                                                                           |
+| Documentation                   | How good is our documentation?                                                                                                                                         |
+| Readme                          | Do we have a good README?                                                                                                                                              |
+| Contributor Documentation       | Do we have good documentation and instructions for someone to start contributing?                                                                                      |
+| Response Times                  | How quickly are new posts responded to?                                                                                                                                |
+| Response Quality                | How friendly and helpful are the responses?                                                                                                                            |
+| Sentiment                       | What is the sentiment within external communication channels regarding our own press releases and within our internal communication channels, e.g., mail lists or IRC? |
+| Comments/Discussion             |                                                                                                                                                                        |
+| Issue Template or documentation | Do we have a specific Issue template that every newcomer should follow? Like checklist, reason for raising the issue, etc                                              |
+
+<span id="anchor-175"></span>Meta
+
+How to ensure metrics are not gamed?
+(<https://en.wikipedia.org/wiki/Goodhart%27s_law>)
+
+What are the unintended consequences of providing these measurements?
+
+How can we make sure people understand the metrics correctly and draw
+problematic conclusions?
+
+Next:
+
+  - One pull request per section, to facilitate discussions focused on
+    each section. (Emma and Daniel)
+  - Write a blog post to circulate this? (Emma)
+
+MEETING ABOVE  ^^
+
+<span id="anchor-176"></span>Meeting 2018-05-23 -- ROADMAP
+
+  - Integrate results with the general Metrics group
+    
+      - > Write down all of the goal-question-metric ideas we have in
+        > [*this
+        > document*](https://docs.google.com/document/d/1MzDk84BL7FfHDxbFxJz39M72V2Hfc5Y6oCPhOl6woxo/edit#)
+    
+      - > [*\#14*](https://github.com/chaoss/wg-diversity-inclusion/issues/14)
+        > Migrate Google Docs D\&I GQM approach to this repository
+
+  - Produce reusable outcomes by third parties when measuring D\&I
+    
+      - > [*\#15*](https://github.com/chaoss/wg-diversity-inclusion/issues/15)
+        > Create a method that other communities can reproduce the
+        > report for themselves 
+
+  - Dissemination of the results across several communities
+    
+      - > Open Source Summit NA / Europe
+    
+      - > OSCON
+    
+      - > CHAOSScon NA
+    
+      - > Others
+
+<span id="anchor-177"></span>Meeting \#1
+
+**Links**: 
+
+  - [*Mozilla
+    Wiki*](https://wiki.mozilla.org/Diversity_and_Inclusion_for_Communities_and_Contributors)
+  - [*D\&I Working
+    Group*](https://github.com/chaoss/wg-diversity-inclusion)
+  - [*https://publications.computer.org/software-magazine/2017/06/27/the-social-developer-the-future-of-software-development-call-for-papers/*](https://publications.computer.org/software-magazine/2017/06/27/the-social-developer-the-future-of-software-development-call-for-papers/)
+    
+  - OpenStack Gender Diversity report
+    [*2017S1*](http://superuser.openstack.org/articles/bitergia-intel-report/)
+    and
+    [*2017S2*](http://superuser.openstack.org/articles/gender-diversity-report_v2_openstack/).
+
+**Consulted**
+
+  - > Georg Link
+
+  - > Nicole Huesman
+
+  - > Emma Irwin
+
+  - > Alexander Serebrenik
+
+  - > Daniel Izquierdo
+
+<span id="anchor-178"></span>*Proposed Goals*
+
+Review the following 5 goals for CHAOSS, add in the work your
+organization is already doing.
+
+  - Add in any existing work (of any magnitude) , you are doing that
+    would fall under this goal.
+  - Add in comments or suggestions regarding the goals themselves.
+  - Add your name to the ‘consulted’ list once you are finished with
+    feedback (so we know if we are missing anyone)
+
+<span id="anchor-179"></span>\#1 A set of generic goal-questions-metrics
+curated by the community focused on understanding and measuring
+diversity & inclusion
+
+Generic means here that we have a baseline of questions but how we can
+answer them has to tailored to unique community contexts. However, we
+want to learn from those unique differences.
+
+Generic goals are to understand diversity and inclusion in the
+categories (buckets) of:
+
+***Definitions:***
+
+  - Diversity: How different are the people present?
+
+  - Inclusion: How well do we enable these different people to work
+    together?
+
+  - Retention: How long do different people stay engaged?
+
+  - Attraction: How well do we extend a hand to different newcomers?
+    
+      - > Example: Two people in a room. They can be diverse, but they
+        > don’t have to work together or be there still tomorrow. AND
+        > just because someone is there, doesn’t mean their experience
+        > is good.
+    
+      - > Example: Some minorities are not necessarily visible, do we
+        > want to measure their degree of visibility/outness?
+        > (disability, socio-economic, LGBTIQ, religion)... 
+    
+      - > Example: There may be women within a community that is less
+        > inclusive, but the women are determined to “see it through”
+        > and participate. In this case, retention does not necessarily
+        > reflect the level of inclusion within a community.
+
+  - Diversity and inclusion dimensions of *Demographics*
+
+<!-- end list -->
+
+1.  1.  > Gender Spectrum
+    
+    2.  > Identify as transgender
+    
+    3.  > Age / e.g., youths?
+    
+    4.  > Location/Region/Country
+    
+    5.  > Access to Technology aka (sub for education)
+    
+    6.  > Socio economic status
+    
+    7.  > Tenure (time with project)
+        
+          - Tenure with the ecosystem?
+    
+    8.  > Race/Ethnicity
+    
+    9.  > First Language
+    
+    10. > Confidence with English
+    
+    11. > Disability
+    
+    12. > Sexual orientation
+    
+    13. > Parents with children
+
+1.  **Goal-Question: What is the diversity and inclusion at
+    *****events*****?**
+    
+    1.  > What is the diversity of *speakers*?
+        
+          - Keynote speakers
+          - Session speakers
+    
+    2.  > What is the diversity of *attendees*?
+        
+          - Within specific sessions
+          - Overall at an event 
+    
+    3.  > Are *Diversity Access Tickets* offered for an event?
+    
+    4.  > What is the *accessibility *to the event for minority groups?
+        > (attribute examples below)
+        
+          - LGBTQ
+          - Disability
+          - Access (quiet rooms)
+    
+    5.  > How does the *Code of Conduct* for events support diversity
+        > and inclusion? (attribute examples below)
+        
+          - Is a Code of Conduct present for an event and visible?
+        
+          - Is the Code of Conduct enforced?
+        
+          - What is the sentiment towards the Code of conduct? 
+            
+              - > Is the CoC trusted? Do people believe that the CoC is
+                > real?
+        
+          - What is the readiness to report CoC violations? 
+            
+              - > Are the steps known within minority groups?
+        
+          - Do we see real differences in diversity and inclusion when
+            we change the CoC?
+    
+    6.  > Does the event host special activities for kids and youths?
+
+> 
+
+1.  **Goal-Question: How diverse are the contributions within the
+    community?**
+    
+    1.  > How does the community collaborate?
+    
+    2.  > Basic metrics such as: code vs non-code, percentage of
+        > contributions, centrality or importance of the code
+        > contribution, emails, code reviews, voting in the code review,
+        > etc.
+    
+    3.  > Measure how collaborative a community is (collaborative →
+        > inclusive)
+
+2.  **Goal-Question: How are we *****communicating *****with
+    contributors, and potential contributors?**
+    
+    1.  > Listening to communities
+        
+          - Text alternatives to video 
+          - Introverts
+          - Bandwidth
+          - Non-english speakers
+    
+    2.  >  Speaking to communities
+        
+          - Non-English Speakers
+          - Speaking to specific demographics
+          - Captioning
+          - Technical Jargon
+
+1.  **Goal-Question: How do we recognize/reward *****good work***** in
+    our community?**
+    
+    1.  > Technical / Non-technical
+    
+    2.  > Small contribution vrs multiple
+    
+    3.  > Type of recognition
+    
+    4.  > Code & non-code
+
+1.  **Goal-Question: How healthy is our community
+    *****leadership*****?**
+    
+    1.  > [*According to Leadership
+        > Principles*](https://discourse.mozilla.org/t/what-s-next-for-volunteer-leadership-in-2018-shared-agreements/25091)
+    
+    2.  > Mentorship and related activities
+
+1.  **Goal-Question: How diverse and inclusive is our
+    *****governance*****?**
+    
+    1.  > Foundation Staff?
+    
+    2.  > Board/Council
+    
+    3.  > Code of Conduct (visible, trusted)
+    
+    4.  > Code of Conduct Enforcement (response sentiment)
+    
+    5.  > Other bureaucratic and administrative foundation teams, e.g.
+        > working groups, committees, ambassador groups, 
+
+1.  **Goal-Question: How diverse and inclusive is our *****project
+    *****place (repo, mailing list?)** 
+    
+    1.  > Documentation
+    
+    2.  > README, CONTRIBUTING.md
+    
+    3.  > Sentiment - Were using (and rewriting) [*FOSS Heartbeat
+        > *](https://sagesharp.github.io/foss-heartbeat/)
+        
+          - PR responsiveness
+          - Etc. / Mail Lists / IRC ?
+    
+    4.  > Comments/Discussion
+
+**
+
+(Meta) but ensuring these measurements, assessments are built into
+software and volunteer lifecycles.
+
+\- AS: are all events the same? Hackathons? Project meetings?
+
+\- leadership
+
+\- Do the contributions show diversity and inclusion?
+
+\- Does the governance of a community foster diversity and inclusion?
+
+Maybe, similar to:
+<https://github.com/chaoss/metrics/blob/master/1_Diversity-Inclusion.md>
+
+Current goals at the OpenStack gender diversity report
+
+  - **Governance and Leadership**:
+    
+      - > Board
+    
+      - > Technical committee
+    
+      - > User committee
+    
+      - > Project Team Leaders
+    
+      - > Ambassadors
+    
+      - > Working groups
+
+  - **Summit and conferences representation**
+    
+      - > Attendees demographics
+    
+      - > Keynote speakers demographics
+    
+      - > Speakers demographics
+
+  - **Code related contributions**
+    
+      - > Code reviews
+    
+      - > Votes in the code reviews
+    
+      - > Core code votes (+2 or -2)
+    
+      - > Commits
+    
+      - > Projects
+    
+      - > Roles as more activity developing new functionality or
+        > maintenance
+    
+      - > Documentation, code, others types of contributions
+
+  - **Non-code related contributions**
+    
+      - > Mailing lists (focused on dev, by language, etc)
+    
+      - > Wiki editions
+
+<span id="anchor-180"></span>Comments on the status of the current set
+of 5 goals of the CHAOSS D\&I working group.
+
+  - This goal aligns with the CHAOSS metrics committee work. This goal
+    also aligns with my work on understanding metrics, specifically it
+    informs the diversity and inclusion metrics. I can bridge the work
+    in the working group with the metrics working group. - Georg Link
+
+  - **Understanding & Measuring (Emma - Mozilla)**
+    
+      - > Baselines for community health (understanding where a project
+        > is ‘right now’ based on a series of research questions.  A
+        > pilot recently conducted in our L10N communities demonstrated
+        > large gaps in our knowledge, which we are now seeking using
+        > additional qualitative and quantitative approaches.
+    
+      - > Hypothesis is that we cannot begin to appropriately measure
+        > until we can better understand our baseline. Understanding
+        > will come through the process of applying intervention, and
+        > observing if diversity numbers fluctuate positively as a
+        > result. We are currently running a pilot to test this
+        > hypothesis, creating safe spaces for women, where diversity
+        > metrics that matter - will be number of women, contributions
+        > by women, and positive sentiment in communication channels.
+    
+      - > Our D\&I survey was a first attempt to understand involved
+        > metrics, and we have some [*1.0 for surveys from
+        > that.*](https://medium.com/@sunnydeveloper/what-we-learned-about-gender-identity-in-open-source-d9acea0b7586)
+        > And working on more
+
+  - Daniel - Bitergia
+    
+      - > One of the first goals when producing the OpenStack gender
+        > report was to understand the technical contributions of women
+        > in the ecosystem. For this, we had to go for a definition of
+        > ‘technical contribution’ and then start measuring those.
+    
+      - > Our approach is to use a Goal-Question-Metric approach that
+        > helps in first place to focus the analysis (eg: understand the
+        > gender diversity of the technical and non-technical
+        > contributions of a given community), then the questions (eg:
+        > what is the population of women participating in Git? What’s
+        > the population of women participating in Gerrit? How many of
+        > them are actually reviewing code? How many of them are core
+        > reviewers in OpenStack?). And finally the metrics: (eg: number
+        > of commits, relative number of commits, number of core code
+        > reviewers, etc).
+    
+      - > The initial goal of the analysis was based on feedback from
+        > the community (eg: tweets asking for technical contributions
+        > of women), challenges by the working groups in OpenStack and
+        > other communities such as Apache (eg: Women of OpenStack:
+        > [*https://wiki.openstack.org/wiki/Women\_of\_OpenStack*](https://wiki.openstack.org/wiki/Women_of_OpenStack)),
+        > and requirements from the foundation level as having in mind a
+        > more qualitative approach such as keynote speakers,
+        > bureaucracy at the foundation, summits attendance, etc. 
+
+  - Alexander - TU/e
+    
+      - > Discussion on the CHAOSS mailing list. Measuring diversity can
+        > be independent from the domain (as long as groups are
+        > defined). Well-known examples of such measures are the Blau
+        > index, and econometric inequality indices such as Gini, Theil
+        > etc. (see discussion with Daniel German, Tom Mens, yt in the
+        > mailing list)
+    
+      - > What about measring possible *antecedents and consequents* of
+        > diversity? For instance, politeness of the communication
+        > hopefully will help? I’ve heard that at GHC 2017 a more senior
+        > woman developer recommended younger women-developers to check
+        > whether the project has a Code of Conduct before joining the
+        > project.
+    
+      - > What diversity axes do we want to measure? So far, the
+        > discussion mostly has focussed on gender (women vs men);
+        > however, gender more complex than this binary and there are
+        > many additional diversity axes.
+
+<span id="anchor-181"></span>\#2 Second learn good practices from open
+source communities on improving their diversity and inclusion
+
+  - To provide actionable good practices is the logical next step of
+    providing metrics. I have a personal interest in learning about good
+    practices and it also informs my academic work. - Georg Link
+
+  - We are working to do this via D\&I in Open Source Call which can
+    facilitate this**(Emma, Mozilla) **
+
+  - Daniel - Bitergia
+    
+      - > As we were covering in the first step the ‘awareness’ of the
+        > community and in second place the question ‘what to measure’.
+        > Our third goal was to understand and include other results to
+        > start making decisions on the existing data. This step was
+        > focused on bringing other experiences to the working group, so
+        > we were able to have a better perspective of what D\&I means
+        > and the approaches that people are following with this
+        > respect.
+
+  - Alexander; are we looking at activities targeting the communities
+    themselves or also reaching outside of the (current) communities,
+    e.g., Summer of Code-like initiatives, outreach at schools?
+
+<span id="anchor-182"></span>\#3 Produce useful software to measure
+diversity from a quantitative point of view. This is expected to produce
+generic software to analyze several repositories of information such as
+Git repositories or Mailing lists
+
+  - This goal aligns with the CHAOSS software committee. Producing such
+    software (or other tools) also informs the metrics that we
+    contribute to the CHAOSS metrics committee. - Georg Link
+
+  - We are investing in the next phase of FOSS Heartbeat (sentiment
+    analysis in Github, could be applied to other software - and we
+    might have budget to invest in that) **(Emma, Mozilla)**
+
+  - Daniel - Bitergia
+    
+      - > The software produced was pretty focused on the OpenStack
+        > case. However, this could be generalize for other communities
+        > quite easily. Indeed GrimoireLab already supports gender
+        > analysis, and GrimoireLab already supports around 30 data
+        > sources. This means that in a quick way, Grimoirelab can
+        > populate databases (from a quantitative point of view) of
+        > those 30 data sources and produce panels with gender
+        > information for each of those.
+    
+      - > GrimoireLab adds and enriches existing information with third
+        > party APIs such as genderize.io. This means that GrimoireLab
+        > is currently providing the infrastructure to retrieve and have
+        > a first dataset with that data. What GrimoireLab does not take
+        > into account is the ‘quality’ of such data and this depends on
+        > the user of the platform. There are cases where names need to
+        > be updated. GrimoireLab helps with that process, but do not
+        > provide 100% real data with respect to gender info.
+    
+      - > However, GrimoireLab is able to produce databases in a quick
+        > way for thousands of developers at the same time (eg: the
+        > OpenStack database contains \>10K different identities).
+
+  - Alexander
+    
+      - > We have multiple sources of info in addition to git
+        > repositories and mailing lists (StackOverflow, code review
+        > systems, bug trackers, meeting logs…). 
+
+<span id="anchor-183"></span>\#4 Good practices on how to deal with such
+data, maintain and ways of collaboration with open source communities.
+
+  - This goal is a necessary consequence of collecting data and the work
+    group can provide the forum to exchange and document these good
+    practices. - Georg Link
+
+  - We are working on strategy for handling data, including thresholds
+    for when we visualize data that includes certain demographics.
+    **(Emma ,Mozilla)**
+
+  - We are also asking hard questions about consent, and access to data.
+    For example if people have not consented to their data being used in
+    genderize.io should we be doing it?  If people give us their PII,
+    and we use it to collect information about the , should we be asking
+    for consent to do that when we collect their PII? (probably) (Emma,
+    Mozilla)
+
+  - Daniel - Bitergia
+    
+      - > The way we’re handling the data is to give private access to
+        > certain members of the OpenStack analysis. As we’re dealing
+        > with private data, this should have restricted access.
+        > However, we have not found a proper way to let the community
+        > improve themselves the datasets.
+
+  - Alexander
+    
+      - > There are some generic recommendations on handling personal
+        > data
+
+<span id="anchor-184"></span>\#5 A method that other communities can
+reproduce the report for themselves.
+
+  - This goal aligns with the overall CHAOSS mission. - Georg Link
+
+  - Daniel-Bitergia
+    
+      - > Our initial goal here would be to produce a proper GQM
+        > approach that we all agree. Then provide templates for people
+        > so they have the several areas we would like to have
+        > (governance, attendees, etc), and finally have specific
+        > software so they can run the quantitative analysis by
+        > themselves.

--- a/meetings/raw-meeting-minutes-gdoc-export.md
+++ b/meetings/raw-meeting-minutes-gdoc-export.md
@@ -1,0 +1,10865 @@
+<span id="anchor"></span>DEI Working Group  
+Agenda and Meeting Minutes
+
+Agenda: [*http://bit.ly/chaoss-diwg*](http://bit.ly/chaoss-diwg) 
+
+Connection Details:
+[*https://zoom.us/j/4998687533*](https://zoom.us/j/4998687533)
+
+Videos:
+[*https://www.youtube.com/playlist?list=PL60k37cxI-HRdtbIe-krn9gGlmPez6lfT*](https://www.youtube.com/playlist?list=PL60k37cxI-HRdtbIe-krn9gGlmPez6lfT)
+
+Repository:
+[*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+
+Every Wednesday at 10:00am US Central / 4:00pm UTC / 6:00 pm Central
+Europe Time.
+
+[*Metrics tracking
+sheet*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+
+<span id="anchor-1"></span>August 18, 2021
+
+Facilitator: Ruth
+
+Attendees (How are you feeling today?)
+
+  - 
+  - Elizabeth Barron - had to unexpectedly get a new phone today 
+  - Lauren Phipps
+  - Kafayah Lawal
+  - Amy Marrich - finishing breakfast:)
+  - Matt Cantu - Back in the office\!
+  - J.W.F. – Just heard about the COVID-19 booster doses for U.S. :o
+
+Agenda: 
+
+  - Discussion about Person First language in metrics
+    
+      - > Here’s something more anecdotal:
+        > [*https://theconversation.com/should-i-say-disabled-person-or-person-with-a-disability-113618*](https://theconversation.com/should-i-say-disabled-person-or-person-with-a-disability-113618)
+        
+          - Section at the bottom gives do/don’t list like Inclusive
+            Naming does that might be helpful for our reference:
+            [*https://inclusivenaming.org/language/word-list/*](https://inclusivenaming.org/language/word-list/)
+            [*https://inclusivenaming.org/language/evaluation-framework/*](https://inclusivenaming.org/language/evaluation-framework/)
+
+  - [*Attention to Color
+    Blindness*](https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum_EcKvA/edit)
+    - housekeeping
+    
+      - > AI LW Matt G will clean up the metric for next time
+        
+          - On hold until next week
+
+  - Event Location Inclusivity - [*Event Location
+    Inclusivity*](https://docs.google.com/document/d/1pdndyeAdGgx1LjLlFE_mPr1nDBA7E2ZV5TAlxqbwi_o/edit)
+    
+    
+      - > Kevin is working on this one
+    
+      - > AI Kevin: Finish this metric
+
+  - AI LW Matt C: Write to Jon L regarding tools for archival
+    
+      - > Matt C has the link now, will try it out
+    
+      - > AI Matt Cantu: Try out the tool on this Google Doc --- Test
+        > Run
+
+<span id="anchor-2"></span>
+
+<span id="anchor-3"></span>August 11, 2021
+
+Facilitator: Matt G
+
+Attendees (How are you feeling today?)
+
+  - J.W.F. – I look forward to these meetings\! But I am tired and
+    nonverbal today 😪
+  - Matt Germonprez - Need to buy a water bottle today
+  - Elizabeth Barron - it’s been a rough week :( 
+  - Lauren Phipps - finishing up my class for the summer
+  - Matt Cantu - Having a meh day - but glad to be here\!
+  - Kafayah Lawal- have a final today 
+  - Kevin Lumbard
+
+Agenda: 
+
+  - AI Matt C: Write to Jon L regarding tools for archival
+
+  - Discussion about Person First language in metrics
+    
+      - > Here’s something more anecdotal:
+        > https://theconversation.com/should-i-say-disabled-person-or-person-with-a-disability-113618
+        > 
+        
+          - Section at the bottom gives do/don’t list like Inclusive
+            Naming does that might be helpful for our reference:
+            [*https://inclusivenaming.org/language/word-list/*](https://inclusivenaming.org/language/word-list/)
+            [*https://inclusivenaming.org/language/evaluation-framework/*](https://inclusivenaming.org/language/evaluation-framework/)
+    
+      - > (I can get more references, too, if needed)
+
+  - [*Attention to Color
+    Blindness*](https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum_EcKvA/edit)
+    
+    
+      - > AI: Matt G will clean up the metric for next time
+
+  - Event Location Inclusivity -
+    [*https://docs.google.com/document/d/1pdndyeAdGgx1LjLlFE\_mPr1nDBA7E2ZV5TAlxqbwi\_o/edit*](https://docs.google.com/document/d/1pdndyeAdGgx1LjLlFE_mPr1nDBA7E2ZV5TAlxqbwi_o/edit)
+    
+    
+      - > Kevin is working on this one
+
+  - Psychological Safety has been elevated to PR level for community
+    review:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pull/377*](https://github.com/chaoss/wg-diversity-inclusion/pull/377)
+    
+      - > Thanks\!\!
+    
+      - > Once merged -- add an issue to the Translation repo
+
+  - (If time, can we look at this issue? There are some great ideas in
+    here: https://github.com/chaoss/wg-diversity-inclusion/issues/240)
+
+  - 
+
+<span id="anchor-4"></span>August 4, 2021
+
+Facilitator: Matt C 
+
+Attendees (How are you feeling today?)
+
+  -  
+  - J.W.F. – Adjusting to the new time zone\! UTC+2
+  -  Amy Marrich - breakfast\!
+  -  Matt Germonprez - Feeling pretty good 
+  -  Vinod Ahuja - Attending DEI after long time
+  - Nico Rikken
+  - Matt Cantu - Project Day
+  - Lauren Phipps - getting a new laptop today… bittersweet 
+  - [*Kafayah Lawal*](mailto:klawal@gmav.unomaha.edu)
+
+Agenda
+
+  - Talk about the CHAOSS data ethics policy 
+    
+      - > [*https://docs.google.com/document/d/1lWj33AIhlGpuvjmYTBRDhuEF5UHfp6fPfJ0925o80Bk/edit\#*](https://docs.google.com/document/d/1lWj33AIhlGpuvjmYTBRDhuEF5UHfp6fPfJ0925o80Bk/edit#)
+        > 
+
+  - The tools that are being using in communities 
+    
+      - > Is this a point of discussion for the CHAOSS project? 
+    
+      - > Inclusive Naming Community - Does naming of a project have
+        > negative consequences 
+        
+          - [*https://github.com/get-woke/woke*](https://github.com/get-woke/woke)
+            
+    
+      - > How could this be a metric? 
+    
+      - > Prosebot 
+        
+          - [*https://github.com/apps/prosebot*](https://github.com/apps/prosebot)
+            
+    
+      - > We will sleep on the metric idea
+        
+          - Added to spreadsheet
+    
+      - > SUMMARY: We need an **Inclusive Naming **metric 
+
+  - Badging update
+    
+      - > Upgrading the badging-bot
+    
+      - > Badging Freeze on Sep 5, 2021
+
+  - Swag Stuff
+    
+      - > Badging
+    
+      - > DEI
+
+  - Move forward with Color Blindness? \[Nico Rikken\]
+    [*https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum\_EcKvA/edit*](https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum_EcKvA/edit)
+    
+
+  - Prosebot (Tabled til next week)
+
+<span id="anchor-5"></span>
+
+<span id="anchor-6"></span>July 28, 2021
+
+Facilitator: Matt C 
+
+Attendees
+
+  - Amy M - On the road
+  - Lauren Phipps
+  - Nico Rikken
+  - Matt Cantu - [*Speaker Build
+    Progress*](https://i.ibb.co/2vVdB3P/image.png)
+  - Matt Germonprez - Dogs :(
+  - Trisha
+
+Agenda: 
+
+  - New Metric Ideas
+    
+      - > Event Location Inclusivity
+        
+          - AI Kevin: Draft this
+          - Done
+    
+      - > Event Venue Accessibility
+        
+          - AI Justin: Draft this once kevin is done drafting
+    
+      - > Color Blindness
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/372*](https://github.com/chaoss/wg-diversity-inclusion/issues/372)
+          - Doc:
+            [*https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum\_EcKvA/edit*](https://docs.google.com/document/d/1yZMH0Z9QKawyxJktSqx-rqx6selto3oZsKHum_EcKvA/edit)
+            
+
+  - Possibly add [***Prosebot***](https://github.com/apps/prosebot) to
+    [*https://github.com/chaoss/wg-diversity-inclusion/*](https://github.com/chaoss/wg-diversity-inclusion/issues/372)
+    all CHAOSS Repositories. Among other things, it applies Google’s
+    wordlist, and flags use of potentially non-inclusive language:
+    [*https://developers.google.com/style/word-list*](https://developers.google.com/style/word-list)
+    
+    
+      - > Pilot Repo?
+    
+      - > AI Matt Germonprez, Lauren K, Matt C: Check if this is
+        > available for repos one at a time
+
+  - Inclusive Experience at Event
+    
+      - > [*Inclusive Experience at Event
+        > *](https://docs.google.com/document/d/10nEEHrHzVQxQBbfk8ZuHX0axv9vniOOzhU5VNKEdmps/edit)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/374*](https://github.com/chaoss/wg-diversity-inclusion/pull/374)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/375*](https://github.com/chaoss/wg-diversity-inclusion/issues/375)
+
+  - Badging: 
+    
+      - > Historical Golds will remain
+    
+      - > The badging will change the meaning of Gold, and we should
+        > work in language about transparency.
+    
+      - > Badge versions may be a way to resolve them.
+    
+      - > AI Matt Cantu: Update README for Badging
+        
+          - Add dates for versions
+          - Version Changes
+
+  - AI [*Matt Cantu*](mailto:matt@cantus.email): Update issue for
+    release notes
+
+<span id="anchor-7"></span>July 21, 2021
+
+Facilitator: Sean G
+
+Attendees: 
+
+  -  Elizabeth Barron
+  -  Nico Rikken
+  -  Matt Germonprez - Picked my first eggplant today
+  -  Sean Goggins - BUCKS WIN\!\!\!\!\! 
+  -  Kevin Lumbard 
+  -  Matt Cantu - Working on new projects\!
+  - Amy Marrich
+  - Justin/JWF - Working outside today\! \\o/ But have to jump to
+    another meeting at :30
+  - Ruth Ikegah - Tired but excited for our submission to OSSEU
+
+Agenda/Notes: 
+
+  - global inclusion of event
+    
+      - > Metric name is: “Time Inclusion Metric”
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/368/files*](https://github.com/chaoss/wg-diversity-inclusion/pull/368/files)
+        > 
+    
+      - > A few comments on process text to add and issue to create are
+        > on the PR, and once they are done, PR can be merged. 
+    
+      - > The intention of this metric is to include it as part of the
+        > DEI Badging Process
+        > [*https://github.com/badging*](https://github.com/badging) 
+
+  - Discussion of Badging program
+    
+      - > Family friendliness
+    
+      - > Diversity access tickets
+    
+      - > Description of the process implemented in the GitHub
+        > organization
+        > [*https://github.com/badging*](https://github.com/badging) 
+
+<!-- end list -->
+
+  - Psychological Safety:
+    
+      - > [*https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing*](https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing)
+        > 
+    
+      - > Suggestion: Remove the sample survey questions from the
+        > metrics, include them in a blog post, and incorporate a link
+        > to the blog post in the released metric as a reference. 
+        
+          - e.g.
+            [*https://chaoss.community/blog-post/2020/12/15/di-metrics-definition/*](https://chaoss.community/blog-post/2020/12/15/di-metrics-definition/)
+    
+      - > Some preference for leaving the questions in the metric
+        > itself. 
+    
+      - > We landed on leaving the sample questions in the metric itself
+        > for ease of use. 
+    
+      - > **Metric is READY for conversion to markdown and creation of a
+        > pull request. **
+
+  - Badging Update
+    
+      - > There will be a “badging freeze” on Sep 5, 2021. 
+        
+          - Make “Gold” a little more challenging so that it
+            distinguishes between VERY DEI events and GOOD DEI events. 
+    
+      - > We need to talk about thanking badging reviewers. 
+        
+          - “freECommerce” site? How do we set that up? LF is being
+            consulted. 
+        
+          - Currently gratitude is expressed in email from Matt Snell
+        
+          - Need: Getting connected with LF for the freECommerce site
+            configuration. 
+            
+              - > Red Hat has a store that people can get codes for, in
+                > order to redeem “free stuff”
+            
+              - > Zazzle account is a “store”. If you generate codes,
+                > then you can give those out as “free stuff” / “swag”
+                > for CHAOSS writ large. Possibly add a Zazzle plugin or
+                > link to the website. 
+            
+              - > Amy can help out with specifics she uses at Red Hat 
+
+  - Possibly add “**Prosebot**” to all CHAOSS Repositories. Among other
+    things, it applies Google’s wordlist, and flags use of potentially
+    non-inclusive language:
+    [*https://developers.google.com/style/word-list*](https://developers.google.com/style/word-list)
+    
+
+  - 
+
+\- 
+
+<span id="anchor-8"></span>July 14, 2021
+
+Facilitator: Committee :)
+
+Attendees: 
+
+  -  
+  -  Elizabeth Barron
+  -  
+  -  Justin/JWF - Feeling excited but also packing up for a long-term
+    move tomorrow\! 
+  -  
+  -  
+  - 
+
+Agenda/Notes: 
+
+  - Tabled until next week: 
+    
+      - > Global Inclusion - Link is fixed again\!\!\!
+    
+      - > [*Global Time Inclusion for
+        > Events*](https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC_wEJ-2UfU/edit)
+
+  - Badging Stickers\!\!\!
+    
+      - > Check out these new designs
+    
+      - > Intended first distribution at CHAOSScon in September 2021
+    
+      - > [*https://imgur.com/a/X8qgwQz*](https://imgur.com/a/X8qgwQz)
+
+  - Tabled until next week: Psychological Safety:
+    
+      - > [*https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing*](https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing)
+        > 
+
+  - Review PRs for standardization:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/365*](https://github.com/chaoss/wg-diversity-inclusion/pull/365)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/364*](https://github.com/chaoss/wg-diversity-inclusion/pull/364)
+    
+      - > Merged
+
+  - Tabled until next week: New Metric?
+    
+      - > Event Location Inclusivity
+        
+          - AI Kevin: Draft this
+    
+      - > Event Venue Accessibility
+        
+          - AI Justin: Draft this once kevin is done drafting
+
+  - Badging Update:
+    
+      - > Freeze in August
+    
+      - > Want to make it harder to obtain a gold badge
+    
+      - > Implementing a new bot
+    
+      - > Implementing a way to require badge refreshing for recurring
+        > events
+    
+      - > A lot of applications have been from the same group of folks,
+        > who have the process pretty well down
+
+<span id="anchor-9"></span>July 7, 2021
+
+Facilitator: Elizabeth Barron
+
+Attendees: 
+
+  - Matt Germonprez - Wearing my Top Gun cat tshirt
+  - Matt Cantu - There’s a cat in my backyard\!\!\!
+  - Lauren Phipps - going to be presenting at a conference next week\!
+  - Elizabeth Barron
+  - Sean Goggins - Bucks in Five.
+  - Emily Brown- having a lazy day
+  - Justin/JWF - Sleepy, rainy day\!
+  - Georg Link - 
+  - [*Amy Marrich*](mailto:amy@demarco.com) - finished breakfast\!
+  - Kevin Lumbard
+
+Agenda/Notes: 
+
+  - DEI Survey -- CHAOSS Contributions 
+    
+      - > Data will be available at data.world
+
+  - Global Inclusion - Link is fixed again\!\!\!
+    
+      - > [*Global Time Inclusion for
+        > Events*](https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC_wEJ-2UfU/edit)
+
+  - Psychological Safety:
+    
+      - > [*https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing*](https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit?usp=sharing)
+        > 
+
+> ![](Pictures/1000020100000280000001684BFE4A1CAF7C9A92.png)\*quokka
+
+> 
+
+> ![](Pictures/10000201000003E80000029BB122A551D0294CFE.png)Deer
+
+> 
+
+> ![](Pictures/10000201000002800000029B5127AFA4493423CD.png)Seal of
+> Approval
+
+> 
+
+  - New Metric?
+    
+      - > Event Location Inclusivity
+        
+          - AI Kevin: Draft this
+    
+      - > Event Venue Accessibility
+        
+          - AI Justin: Draft this once kevin is done drafting
+
+<span id="anchor-10"></span>
+
+<span id="anchor-11"></span>June 30, 2021
+
+Facilitator: Matt Cantu
+
+Next week: Elizabeth
+
+Attendees 
+
+  - Elizabeth Barron
+  - Matt Germonprez - running in humidity is not awesome
+  - Lauren Phipps
+  - [*Matt Cantu*](mailto:matt@cantus.email) - Trying out Windows 11
+  - Dawn Foster
+  - Emily Brown
+  - Sean Goggins
+  - Nicole Huesman 
+  - J.W.F. – Getting more vaccine jabs today, but not for COVID\!
+  - Amy Marrich
+
+<span id="anchor-12"></span>
+
+Agenda/Notes: 
+
+  - Questions about Global (Time) Inclusion
+
+  - New Metric: [*Trust and
+    Safety*](https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit)
+    
+      - > AI: Elizabeth will help smooth out the front of the metric
+
+  - [*Inclusive Experience at Event
+    *](https://docs.google.com/document/d/10nEEHrHzVQxQBbfk8ZuHX0axv9vniOOzhU5VNKEdmps/edit?usp=sharing)
+
+  - All In Project 
+    
+      - > Open Source DEI for Students
+        
+          - Students from HBCUs who would not otherwise have opportunity
+            to connect with open source project and organizations
+          - Process: Identify students and build the framework
+          - Not sure what that process looks like
+    
+      - > Open Source DEI for Maintainers
+        
+          - Maintainers who created an open source project without
+            initial consideration of DEI
+          - Process: Center DEI in the work that they do
+          - Providing resources, support, education
+          - Not sure what that process looks like
+    
+      - > Points of connection?
+
+  - DEI Reflection 
+    
+      - > Update the template? 
+        
+          - [*https://github.com/chaoss/metrics/pull/192*](https://github.com/chaoss/metrics/pull/192)
+            
+    
+      - > Intersectional Metrics? Cross WG metrics 
+    
+      - > DEI Council -- how to? 
+        
+          - Draft Document to document ideas 
+            
+              - > AI: Matt G. 
+            
+              - > We could talk through this as a working document 
+            
+              - > Include language in the governance document to include
+                > why we do what we do
+            
+              - > In the governance - a community statement --
+                > describing how we do what we do. 
+                
+                  - Some of this is in the community handbook. 
+                    
+                      - > [*https://handbook.chaoss.community/community-handbook/about/values*](https://handbook.chaoss.community/community-handbook/about/values)
+                        > 
+            
+              - > Fedora example: 
+                
+                  - [*https://docs.fedoraproject.org/en-US/project/\#\_our\_community*](https://docs.fedoraproject.org/en-US/project/#_our_community)
+                    
+        
+          - Should we update the CHAOSS charter
+            
+              - > Ping Georg and Nicole to bring this to the board. 
+            
+              - > [*https://chaoss.community/about/charter/*](https://chaoss.community/about/charter/)
+                > 
+        
+          - Return this to the Audit team for directions forward. 
+    
+      - > Inspiration\!
+
+![](Pictures/1000020100000800000004813CF04DCEA8E31A64.png)
+
+> 
+
+  - Inclusive Naming within the CHAOSS project
+    
+      - > [*https://inclusivenaming.org/*](https://inclusivenaming.org/)
+        > 
+        
+          - Groups:
+            [*https://inclusivenaming.org/workstreams/*](https://inclusivenaming.org/workstreams/)
+            
+            
+              - > Language group 
+            
+              - > Tooling group 
+        
+          - More of a big picture organization 
+
+<span id="anchor-13"></span>June 23, 2021
+
+Facilitator: Matt Germonprez 
+
+Attendees
+
+  -  Matt Cantu - weird day
+  - J.W.F. – This is my fifth meeting today\! But I get to end earlier
+    in the afternoon, so it works out :)
+  - Matt Germonprez - Lovely walk today (and run) 
+  - Elizabeth Barron - hi friends\! 
+  - Lauren Phipps - hey everyone\!
+  - Dawn Foster - feeling a little sleepy the day after my 2nd covid jab
+    😴
+  - Emily Brown
+
+<span id="anchor-14"></span>
+
+Agenda/Notes: 
+
+  - New Metric: [*Trust and
+    Safety*](https://docs.google.com/document/d/1x1I6gdivnj60fYk-rYijWCWjVeS6vBWx5LoHqIYOM5M/edit)
+    
+      - > AI: Elizabeth will help smooth out the front of the metric
+
+  - [*Inclusive Experience at Event
+    *](https://docs.google.com/document/d/10nEEHrHzVQxQBbfk8ZuHX0axv9vniOOzhU5VNKEdmps/edit?usp=sharing)
+
+  - All In Project 
+    
+      - > Points of connection? 
+
+  - DEI Reflection 
+    
+      - > Update the template? 
+    
+      - > Intersectional Metrics? Cross WG metrics 
+
+  - Inclusive Naming within the CHAOSS project 
+
+<span id="anchor-15"></span>
+
+<span id="anchor-16"></span>June 16, 2021
+
+Facilitator: Matt Cantu 
+
+Attendees
+
+  - Matt Cantu - Feeling productive today
+  - Matt Germonprez - Feeling Good Today
+  - Nick Vidal - Cold morning in Brazil (13 Celsius now, but sunny)
+  - Elizabeth Barron - it’s gorgeous in Cincinnati Ohio today\!
+  - Amy Marrich - RIP chicken \#16
+  - Lauren Phipps - excited to join for my first meeting\!
+
+Agenda/Notes:
+
+  - Event Demographics 
+    
+      - > \[AI LW: SG\] - Move attendee demographics and speaker
+        > demographics as “demographics”. 
+        
+          - [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+            
+          - 6/9/2021 Meeting Conclusion: “Event demographics should
+            exist, but “demographics” should be defined more generally,
+            and then gathered in distinct ways for events and tools for
+            gathering project diversity, more widely construed.”
+    
+      - > Creating new event metrics
+        > ([*msnell@unomaha.edu*](mailto:msnell@unomaha.edu): Will
+        > enumerate some of the metrics under here for the next meeting.
+        > ) 
+        
+          - Measure the \[diversity\]
+            (https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data)
+            of attendees, speakers, and volunteers. This can include
+            gender identity, age, first language, and dis/ability.
+            \[backgrounds\]
+        
+          - Forms of attendee support (other than family)
+        
+          - Event Equity
+            
+              - > ?
+            
+              - > ?
+        
+          - [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+            
+
+  - Add enforcement component to code of conduct metric(s)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/363*](https://github.com/chaoss/wg-diversity-inclusion/issues/363)
+        > 
+    
+      - > Agree this is important. Action item Elizabeth B :)
+    
+      - > For ideas - see enforcement section:
+        > [*https://www.contributor-covenant.org/version/2/0/code\_of\_conduct/*](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)
+        > 
+    
+      - > [*https://opensource.creativecommons.org/community/code-of-conduct/enforcement/*](https://opensource.creativecommons.org/community/code-of-conduct/enforcement/)
+
+  - 3 potential new metrics:
+    
+      - > Trust (& Social Capital)
+    
+      - > Psychological Support
+    
+      - > Fairness (& Equity?)
+        
+          - Focus area? Let this marinate. 
+    
+      - > AI Matt C: Start one of these metrics from a template
+        
+          - [*CHAOSS DEI: Psychological
+            Support*](https://docs.google.com/document/d/1CgVxuKleZvjlG2iqFNHUwAYvu9eyKrbL5xSGQ8IdaoQ/edit?usp=sharing)
+          - AI Matt Cantu: Add more content
+
+  - Focus Areas
+    
+      - > \[AI: SG\] : Create a Pull Request in[*
+        > DEI*](https://github.com/chaoss/wg-diversity-inclusion) to
+        > make these changes, and make “Leadership” into “Leadership and
+        > Governance” as a heading.
+
+  - DEI Council?
+    
+      - > Open question: Do we need ongoing DEI reflection for the
+        > CHAOSS community?
+
+<span id="anchor-17"></span>June 9, 2021
+
+Facilitator: Sean Goggles
+
+Attendees
+
+  - Matt Cantu - 
+  - Sean Goggins 
+  - Dawn Foster
+  - Kevin Lumbard
+  - Elizabeth Barron
+
+Agenda/Notes:
+
+  - 3 potential new metrics:
+    
+      - > Trust (& Social Capital)
+    
+      - > Psychological safety
+    
+      - > Fairness (& Equity?)
+        
+          - Focus area? Let this marinate. 
+    
+      - > AI Matt C: Start one of these metrics from a template
+
+  - Micro, Mezzo, and Macro
+
+  - Add enforcement component to code of conduct metric(s)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/363*](https://github.com/chaoss/wg-diversity-inclusion/issues/363)
+        > 
+    
+      - > Agree this is important. Action item TBD. 
+    
+      - > For ideas - see enforcement section:
+        > [*https://www.contributor-covenant.org/version/2/0/code\_of\_conduct/*](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)
+        > 
+
+  - Event Demographics 
+    
+      - > Creating new event metrics
+        > ([*msnell@unomaha.edu*](mailto:msnell@unomaha.edu): Will
+        > enumerate some of the metrics under here for the next meeting.
+        > ) 
+        
+          - Measure the \[diversity\]
+            (https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data)
+            of attendees, speakers, and volunteers. This can include
+            gender identity, age, first language, and dis/ability.
+            \[backgrounds\]
+        
+          - Forms of attendee support (other than family)
+        
+          - Event Equity
+            
+              - > ?
+            
+              - > ?
+    
+      - > \[AI LW: SG\] - Move attendee demographics and speaker
+        > demographics as “demographics”. 
+        
+          - [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+            
+          - 6/9/2021 Meeting Conclusion: “Even demographics should
+            exist, but “demographics” should be defined more generally,
+            and then gathered in distinct ways for events and tools for
+            gathering project diversity, more widely construed.”
+
+  - Focus Areas
+    
+      - > \[AI: SG\] : Create a Pull Request in[*
+        > DEI*](https://github.com/chaoss/wg-diversity-inclusion) to
+        > make these changes, and make “Leadership” into “Leadership and
+        > Governance” as a heading. 
+
+<span id="anchor-18"></span>June 2, 2021
+
+Attendees
+
+  - Matt Germonprez - Son is swimming at the Olympic Trials 
+  - Sean Goggins, Feeling good\!
+  - Matt Cantu - Glad to be back\!
+  - Nick Vidal - Lunch time
+  - Amy Marrich - Breakfaasting
+  - Elizabeth Barron - Exhibiting at a big art show this weekend, yay\!
+  - J.W.F. – I am off this week… so a relaxing morning today\!
+
+Agenda/Notes:
+
+  - Let’s revisit the Focus Areas. Are they good? Should they change? 
+    
+      - > Maybe these *governance* metrics should be included in
+        > *Leadership* and *“Project and Community”*?
+        
+          - Board/Council Diversity (L)
+          - Code of Conduct for Project (PC)
+          - Code of Conduct Enforcement (PC)
+          - Team/Module Ownership Diversity (PC)
+          - Foundation Staff Diversity (L)
+          - Path to Influence (L)
+    
+      - > \[AI: SG\] : Create a Pull Request in[*
+        > DEI*](https://github.com/chaoss/wg-diversity-inclusion) to
+        > make these changes, and make “Leadership” into “Leadership and
+        > Governance” as a heading. 
+    
+      - > Question about projects with many layers of leadership (larger
+        > projects) : Example (SIG’s, and SIG Chairs, and “Projects”)
+
+  - Add an enforcement component (new issue) : In exchange for keeping
+    it (enforcement) as a separate metric, as previously noted in the
+    spreadsheet. 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/363*](https://github.com/chaoss/wg-diversity-inclusion/issues/363)
+        > 
+
+  - Event Demographics 
+    
+      - > Determine the \[diversity\]
+        > (https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data)
+        > of attendees, speakers, and volunteers. This can include
+        > gender identity, age, first language, and dis/ability.
+        > \[backgrounds\]
+        
+          - Is this okay? 
+    
+      - > Encourage people to add themselves as contributors 
+    
+      - > \[AI: SG\] - Move attendee demographics and speaker
+        > demographics as “demographics”. 
+        
+          - [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+            
+
+  - Interesting article about inclusive metrics: [*How to Measure
+    Inclusion in the
+    Workplace*](https://hbr.org/2021/05/how-to-measure-inclusion-in-the-workplace)
+    
+    
+      - > 3 potential new metrics:
+        
+          - Trust
+          - Psychological safety
+          - Fairness
+
+<span id="anchor-19"></span>May 26, 2021
+
+Attendees (AND Emoji how you are feeling today)
+
+  - Matt Germonprez 😺
+  - Emily Brown - feeling 
+  - Nick Vidal - 
+  - Sean Goggins - Here. 
+  - Kevin Lumbard
+  - J.W.F. – 😌
+
+Agenda/Notes:
+
+  - Facilitator for next week? 
+    
+      - > Sean Goggins\! Thanks\!
+
+  - Take a minute to everyone look back through our minutes to see if
+    there are items that we should not forget about. 
+    
+      - > Potential New Metric: Connection Bandwidth, paying particular
+        > attention to the impact of poor bandwidth on contributor
+        > diversity. 
+    
+      - > Survey update 
+    
+      - > Zooming out to a higher level: Should we revisit the metric
+        > Focus Areas we use? Are we missing ones? Do some need updates?
+        
+          - Event Diversity
+          - Contributor Community Diversity
+          - Communication Inclusivity
+          - Recognition of Good Work
+          - Leadership
+          - Governance
+          - Project and Community
+
+  - Let’s archive the older minutes 
+    
+      - > Connect with Matt C. to get an update on the archiving 
+    
+      - > Figure this out. 
+
+  - CHAOSScon
+    
+      - > Keynote from the DEI working group? 
+        
+          - Generally yes. 
+    
+      - > Our own results from the DEI reflection - Justin?
+    
+      - > Date: Sept 30, 2021
+
+  - Documentation Discoverability is now under community review
+    
+      - > AI: Kevin to help with finalizing steps here. Thanks Kevin\!
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/313*](https://github.com/chaoss/wg-diversity-inclusion/issues/313)
+        > 
+
+  - Event Demographics
+    
+      - > [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+        > 
+        
+          - Add disclaimer that this is under review
+          - Issue PR in MD for the new metric
+          - Create new Issue pointing out the new metric 
+          - In the release notes -- note that this is one new metric and
+            there are two metrics that are being deleted (or archive) 
+          - AI: Matt G will get started
+
+  - Inclusive Leadership
+    
+      - > Updating 
+        
+          - [*https://chaoss.community/metric-inclusive-leadership/*](https://chaoss.community/metric-inclusive-leadership/)
+            
+          - [*https://github.com/chaoss/wg-diversity-inclusion/pull/360/files*](https://github.com/chaoss/wg-diversity-inclusion/pull/360/files)
+            
+
+  - IEEE SA Open
+    
+      - > Matt C. is leading some of the badging efforts there
+    
+      - > Technical advisory group workshop coming up on June 16th. 
+        
+          - Unconference -- with breakout rooms 
+        
+          - Technical Advisory Group (TAG) Workshop led by volunteers of
+            TAG on the IEEE SA OPEN platform
+            
+              - > [*https://saopen.ieee.org/upcoming-events/*](https://saopen.ieee.org/upcoming-events/)
+                > 
+            
+              - > TAG[
+                > ](https://opensource-connect.ieee.org/technical-advisory-group/channels/town-square)[*Mattermost*](https://opensource-connect.ieee.org/technical-advisory-group/channels/town-square)
+                > chat- join in on community discussions
+            
+              - > Title: TAG you're IT: Technical Infrastructure in Open
+                > Source Communities
+            
+              - > Registration link (will be up shortly)
+            
+              - > [*Event
+                > schedule*](https://opensource.ieee.org/workshops/june-tag-workshop/20210616-tag-workshop/-/blob/main/Event%20Information/20210616-event-schedule.md)
+            
+              - > [*Registration
+                > link*](https://opensource.ieee.org/workshops/june-tag-workshop/20210616-tag-workshop/-/issues/new?issuable_template=workshop-registration)
+
+<span id="anchor-20"></span>May 19, 2021
+
+Attendees (AND How you are feeling today\!)
+
+  - Matt Germonprez - Doing just fine. Got fiber to the house. 
+  - Amy Marrich - dragging but vaccinated 
+  - Elizabeth Barron - a gorgeous day and my yard is cicada free so
+    far\! 
+  - Dawn Foster - crazy weather today. Sun, hail, all the weathers.
+  - Beth Hancock - Rain and rain and rain and book fair. Generally
+    happy.
+  - Justin – Also dragging and also vaccinated, since Monday.
+  - Emily Brown
+  - Kevin Lumbard
+
+Agenda/Notes:
+
+  - CHAOSS DEI reflection 
+    
+      - > Survey under review at UNO IRB
+        
+          - Process for distributing input welcome 
+          - In the initial email let people know that there will be
+            several reminders. 
+          - “Now is your only chance to opt-out if you don’t want to get
+            annoying reminders to complete the survey.”
+    
+      - > Working with Emily Brown on improving website accessibility 
+        
+          - Tab through
+          - Alt text 
+
+  - CHAOSS and GitHub and LF Research 
+    
+      - > D\&I questions from 2017 GH Developer survey
+        > (https://opensourcesurvey.org/2017/)
+    
+      - > Build questions around CHAOSS DEI Focus Areas 
+
+  - CHAOSS Badging 
+    
+      - >  DPDK Summit 
+
+  - Documentation Discoverability:
+    
+      - > [*https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit\#*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit#)
+        > 
+    
+      - > Ready for release 
+        
+          - Finalize this
+          - Issue:
+            [*https://github.com/chaoss/wg-diversity-inclusion/issues/313*](https://github.com/chaoss/wg-diversity-inclusion/issues/313)
+            
+          - PR:
+            [*https://github.com/chaoss/wg-diversity-inclusion/pull/362*](https://github.com/chaoss/wg-diversity-inclusion/pull/362)
+            
+
+<span id="anchor-21"></span>May 12, 2021
+
+Attendees:
+
+  - Dawn Foster - 
+  - J.W.F. – a rainy, wet morning, and I feel the sleepiness setting
+    in\!
+  - Matt Germonprez - Went to some friends last night. It was nice. 
+  - Vinod Ahuja 
+  - Elizabeth Barron - coffeeeeee
+
+Agenda/Notes:
+
+  - Documentation Discoverability:
+    
+      - > [*https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit\#*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit#)
+        > 
+    
+      - > Ready for release\! 
+    
+      - > Comments from the final editing 
+        
+          - **\*\*Editability\*\*** — Documentation is easy to update by
+            any contributor, including instructions about how to make
+            updates. This improves accuracy and clarity of documentation
+            from a wide variety of contributors with different skill
+            levels.
+            
+              - > This will move to Documentation Usability (released
+                > metric)
+        
+          - **\*\*Geographic Access\*\*** — Documentation can be
+            accessed by users who may be subject to various internet
+            restrictions. This may require use of hosted platforms
+            instead of x-as-a-service platforms, which may be blocked by
+            certain entities or states. 
+        
+          - **\*\*Mobile Access\*\*** — Documentation can be viewed,
+            accessed, and navigated by mobile computing devices or with
+            poor broadband connections
+            
+              - > These will move to Documentation Accessibility 
+        
+          - **\*\*Portability\*\*** — Documentation is easy to move to
+            another format / device.
+            
+              - > This is simply removed 
+        
+          - Ask questions regarding readability and scanability such as:
+            
+            
+              - > Does the documentation use organizing constructs, such
+                > as:
+                
+                  - Headings
+                  - Text and Code Blocks
+                  - Bullets versus Paragraphs
+                  - Anchors
+
+FOR Documentation Usability 
+
+  - Provide a quick micro-survey with only one question to readers of
+    the documentation (i.e., bottom-page or popup when leaving page): 
+    
+      - > Yes/No question: Was this documentation page reasonably
+        > accessible to you?
+    
+      - > Likert Scale \[1-x\]: How accessible was this documentation to
+        > you? 
+    
+      - > Short Answer: How do you feel about the accessibility of the
+        > documentation?
+    
+      - > FOR Documentation Accessibility 
+
+<!-- end list -->
+
+  - Event Demographics: 
+    
+      - > [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+        > 
+    
+      - > Next steps: 
+        
+          - Remove Speaker Demographics
+          - Remove Attendee Demographics 
+          - Submit Event Demographics as the new, single metric
+
+  - Community survey coming soon™
+    
+      - > Hopefully by the end of the May, the independent team
+        > conducting an audit of diversity, equity, and inclusion in the
+        > CHAOSS community will share a survey with all CHAOSS
+        > contributors
+    
+      - > Helpful opportunity to learn about our community—**keep an eye
+        > out in the next few weeks for more info**\!
+
+<span id="anchor-22"></span>
+
+<span id="anchor-23"></span>May 5, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Emily Brown- feeling good 
+  - Amy Marrich - Breakfast\!
+  - Matt Germonprez - hello\!\! 
+  - Elizabeth Barron - hiiii
+  - Sean Goggins - Feeling what 3 straight nights of sleep “is”.
+  - Dawn Foster - running late
+  - J.W.F. – A little scattered today\!
+  - Yash Prakash - Great\!\!\!
+
+Agenda 
+
+  - ATO submission is in -- thanks Ruth and Matt S/C 
+
+  - DEI Badging Updates? 
+    
+      - > Creating open source marketing workshop
+    
+      - > Got to talk about the badging initiative at the IEEE SA Open
+        > Marketing Advisory Group 
+
+  - Issues and PRs
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+        > 
+    
+      - > If you see a metric idea you are interested in, feel free to
+        > run with it\! Template is here:
+        > [*https://github.com/chaoss/metrics/blob/master/resources/metrics-template.md*](https://github.com/chaoss/metrics/blob/master/resources/metrics-template.md)
+        > (copy and paste this template in a google doc for easier
+        > collaboration)
+
+  - CHAOSS DEI Reflection 
+    
+      - > Preliminary Community Survey 
+        
+          - [*https://docs.google.com/forms/d/1f\_38eeKBaz8bTqZmblQOc82H-yU-FDFmBqScWKBpjcs/edit*](https://docs.google.com/forms/d/1f_38eeKBaz8bTqZmblQOc82H-yU-FDFmBqScWKBpjcs/edit)
+            
+    
+      - > Following the WG question, if ‘no’ 
+        
+          - What can we do differently that you don’t think the current
+            WGs are doing? 
+
+  - Event Demographics (Attendee and Speaker Demographics as one metric)
+    
+      - > [*https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit*](https://docs.google.com/document/d/1xrAPH4OzxIGL-2WNz2XZYSFSFgOoZe06Q0AaMBT0JQI/edit)
+        > 
+
+  - Choosing Chairs for this Working Group to be listed on the repo
+    
+      - > Georg? 
+    
+      - > Matt C/S and Ruth? 
+    
+      - > Amy
+    
+      - > Elizabeth 
+
+  - Come see us in Slack\! We also have a new channel for newcomers
+    called \#office-hours. Join Slack here:
+    [*https://join.slack.com/t/chaoss-workspace/shared\_invite/zt-ptka3wu9-ey\~fd3lh7gj2659WVVzFMQ*](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-ptka3wu9-ey~fd3lh7gj2659WVVzFMQ)
+    
+
+<span id="anchor-24"></span>April 28, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Charise Van Liew - hopeful
+  - Beth Hancock - Full of mucus...ugh
+  - Matt Germonprez - I’m using my computer’s mic. My son took my other
+    one. 
+  - Matt Snell: My music today: Snail’s House - Pixel Galaxy :)
+  - Elizabeth Barron - hello\!
+  - Sean Goggins - Its like Seattle outside, and I am in a garage.
+    \#Nirvana2
+  - Ruth Ikegah - Scattered day
+  - [*Amy Marrich*](mailto:amy@redhat.com)-busy busy
+  - [*jflory@unicef.org*](mailto:jflory@unicef.org) – It’s been a
+    while\! Happy to be here, but def tired.
+  - Yash Prakash - great day :D
+  - Anita Ihuman - Meh day
+
+Agenda:
+
+  - ATO and OSS EU Submissions
+    
+      - > DEI Badging Program
+    
+      - > [*https://docs.google.com/document/d/18gKwE0fFGbvy70tuNynqQrN9Sq10YwuZYkaTC4\_JXKM/edit*](https://docs.google.com/document/d/18gKwE0fFGbvy70tuNynqQrN9Sq10YwuZYkaTC4_JXKM/edit)
+    
+      - > Let’s try to finalize this today
+    
+      - > ATO 
+        
+          - Deadline this week
+        
+          - AI: Ruth to check out the ATO submission in a bit more
+            detail. (April 30th deadline).
+            
+              - > Talk title 
+            
+              - > Abstract (no limit)
+            
+              - > Speaker Bio (second speaker?)
+            
+              - > No: Expectations of audience
+
+  - Standard Structure for README.md in each WG repo
+    
+      - > [*Standard Structure for README.md in
+        > WGs*](https://docs.google.com/document/d/1pfipIiaemdtdiDQpvY7jOKhKzsv_3lXLLsbJiByl5GU/edit?usp=sharing)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/358*](https://github.com/chaoss/wg-diversity-inclusion/issues/358)
+
+  - Matrix room as a way to bridge between IRC and Slack 
+    
+      - > [*https://matrix.to/\#/\#chaoss-community:matrix.org*](https://matrix.to/#/#chaoss-community:matrix.org)
+        > 
+
+  - Updating Attendee Demographics 
+    
+      - > [*CHAOSS Metrics: V2: Level of
+        > Completeness*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/359*](https://github.com/chaoss/wg-diversity-inclusion/pull/359)
+        > 
+    
+      - > Pulling out the inclusive experience from attendee
+        > demographics and making a new metric called Inclusive
+        > Experience at Event 
+        
+          - [*Inclusive Experience at Event
+            *](https://docs.google.com/document/d/10nEEHrHzVQxQBbfk8ZuHX0axv9vniOOzhU5VNKEdmps/edit)
+            
+    
+      - > Should we make a single metric called Demographics (Event
+        > Demographics)
+        
+          - First step -- collapse speaker and attendee demographics
+            into a single metric called Event Demographics 
+            
+              - > [*Demographics*](https://docs.google.com/document/d/1Uk8DFN2Ko1DUmIa7rp9-Qpd1ZHSULNE1jkiWsPGolpM/edit#)
+                > 
+            
+              - > Actually\! AI: [*Matt
+                > Germonprez*](mailto:germonprez@gmail.com) 
+                
+                  - Event Demographics as one metric
+                  - Project Demographics as another metric 
+
+  - Updating Inclusive Leadership 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/360*](https://github.com/chaoss/wg-diversity-inclusion/pull/360)
+        > 
+    
+      - > Continue to retool by reducing the Implementation section 
+
+  - 
+
+<span id="anchor-25"></span>April 21, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  -  Emily Brown- feeling ok
+  -  Matt Germonprez -- I want to eat junk food
+  -  Dawn Foster - enjoying spring\!
+  -  Matt Snell (soon to be Matt Cantu :) - Not so high profile
+  -  Elizabeth Barron - snow is melting, yay
+  -  Yash Prakash - feeling great\!
+
+Agenda:
+
+  - Updating Attendee Demographics 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/359*](https://github.com/chaoss/wg-diversity-inclusion/pull/359)
+        > 
+    
+      - > Pulling out the inclusive experience from attendee
+        > demographics and making a new metric called Inclusive
+        > Experience at Event 
+    
+      - > Should we make a single metric called Demographics (Event
+        > Demographics)
+        
+          - First step -- collapse speaker and attendee demographics
+            into a single metric called Event Demographics 
+
+  - Updating Inclusive Leadership 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/360*](https://github.com/chaoss/wg-diversity-inclusion/pull/360)
+        > 
+    
+      - > Continue to retool by reducing the Implementation section 
+
+  - Standard Structure for README.md in each WG repo
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/358*](https://github.com/chaoss/wg-diversity-inclusion/issues/358)
+
+  - DEI Reflection 
+    
+      - > Two processes: 
+        
+          - How to collect information that could be repeatable by
+            others
+        
+          - How to represent information that would be used by others 
+            
+              - > Findings aimed at CHAOSS 
+            
+              - > Processes to help others 
+
+  - ATO and OSS EU Submissions
+    
+      - > DEI Badging Program
+    
+      - > Link? 
+
+<span id="anchor-26"></span>April 14, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Seunfunmi Adegoke -- exhausted been studying all day, bad internet. 
+  - Dawn Foster - so many meetings today 📅
+  - Matt Germonprez - Eye exam today. First time in a long time. 
+  - Nicole Huesman - sunny day in Portland\!
+  - Elizabeth Barron - I am immortal (or at least vaccinated)
+  - Matt Snell - Soon to be Matt Cantu
+
+Agenda:
+
+  - Metrics
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+    
+      - > Code of Conduct Enforcement
+        
+          - Code of Conduct at Project
+        
+          - Code of Conduct at Event
+        
+          - Should these be two different metrics? In the badging
+            initiative, we currently treat them sort of as a single
+            metric. 
+            
+              - > Make its own metric 
+                
+                  - Training 
+                  - How to report
+                  - [*https://docs.google.com/document/d/1iZHRc2ohY00TGnnPHTkjMghAXQpQEJy7CopJfn59Klw/edit?usp=sharing*](https://docs.google.com/document/d/1iZHRc2ohY00TGnnPHTkjMghAXQpQEJy7CopJfn59Klw/edit?usp=sharing)
+                    
+
+  - New Metric
+    
+      - > Travel support? DEI Support for speakers? 
+        
+          - Travel Support for Speakers:
+            [*https://docs.google.com/document/d/13muazYItEoHuYS6b-XNhIQwU6GhoDRoQgtlA1Ko2KBU/edit?usp=sharing*](https://docs.google.com/document/d/13muazYItEoHuYS6b-XNhIQwU6GhoDRoQgtlA1Ko2KBU/edit?usp=sharing)
+            
+          - Speaker Incentives:
+            [*https://docs.google.com/document/d/13muazYItEoHuYS6b-XNhIQwU6GhoDRoQgtlA1Ko2KBU/edit*](https://docs.google.com/document/d/13muazYItEoHuYS6b-XNhIQwU6GhoDRoQgtlA1Ko2KBU/edit)
+            
+          - Being explicit about what is covered specifically for
+            speakers (vs attendees)
+          - Create separate metric for Speaker Incentives: Speakers
+            typically bear an unpaid burden, important part of
+            increasing DEI of speakerships, provides opportunities,
+            recognizes speakerships as a career booster, ‘travel support
+            priority’ could be an additional incentive, extras on top of
+            flight/hotel, gifts, stipend
+
+  - Should we revisit our released metrics? 
+    
+      - > Sometimes things read well when you are writing them but they
+        > read less well when you are away from them for a while. 
+        
+          - Example:
+            [*https://chaoss.community/metric-inclusive-leadership/*](https://chaoss.community/metric-inclusive-leadership/)
+            
+        
+          - Grammar 
+        
+          - Changes to how the metric should be considered: Events
+            change (for example)
+            
+              - > AI: Matt G. will start taking a look at how some of
+                > the older metrics might be edited. 
+            
+              - > Description: Leadership is central to a
+                > project/community's culture and how the leadership is
+                > determined requires intentional design and
+                > accountability for the inclusion of others. Note the
+                > term leadership may vary depending on the
+                > project/community. Leadership roles have high
+                > visibility and the diversity of this group is
+                > critically important to fostering an inclusive
+                > community.
+
+  - Badging Documents
+    
+      - > Do we have a central place where these are located? 
+        
+          - GitBook:
+            [*https://handbook.chaoss.community/badging/*](https://handbook.chaoss.community/badging/)
+          - Also GH:
+            [*https://github.com/badging/diversity-and-inclusion*](https://github.com/badging/diversity-and-inclusion)
+          - Matt is creating an ‘application review playbook’
+
+  - User Story
+    
+      - > [*https://docs.google.com/document/d/1LjC6XYTzFD5BkBZypRKq--uoqTlrdr3Dd5D37YOgKuo/edit*](https://docs.google.com/document/d/1LjC6XYTzFD5BkBZypRKq--uoqTlrdr3Dd5D37YOgKuo/edit)
+        > 
+
+<span id="anchor-27"></span>April 7, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Germonprez - Nice rain today.
+  - Dawn Foster - catching up after more than a week off\!
+  - Sean Goggins - Its raining cats and dogs
+  - Emily Brown- Feeling better than yesterday
+  - Elizabeth Barron - it’s a beautiful day\! ☀️
+  - Ruth Ikegah - Got good news\! Nominated for a gift box from Google
+    OSS -- NICE\!\!
+  - Nicole Huesman - crazy day yesterday, but doing well today\!
+
+Agenda:
+
+  - Facilitator for Next Week: Nicole H. 
+
+  - Badging Initiative 
+    
+      - > Badge 
+        
+          - Should we provide guidance after the badge is awarded? 
+            
+              - > Social tile? 
+            
+              - > Text to include with the badge? 
+            
+              - > Encourage placement on webpage and associated event
+                > repos?
+                
+                  - Or somewhere on the repo in the README? At the top
+                    of the repo? 
+            
+              - > AI: All? Maybe some text that helps in this regard? 
+    
+      - > Reviewers (We have a good number of folks. Yay\!)
+    
+      - > Events
+    
+      - > Speaker Demographics
+        
+          - Walking back from displaying demographics a bit
+        
+          - Considering more about how DEI is attended to in the
+            selection committee, agenda setting, and keynote selection 
+            
+              - > [*https://medium.com/@hannahfoxwell/should-tech-conferences-be-more-inclusive-5a05a09cd302*](https://medium.com/@hannahfoxwell/should-tech-conferences-be-more-inclusive-5a05a09cd302)
+                > 
+    
+      - > Badged Events
+        
+          - [*https://github.com/badging/event-diversity-and-inclusion*](https://github.com/badging/event-diversity-and-inclusion)
+            
+    
+      - > Changes for Review
+        
+          - [*https://github.com/badging/event-diversity-and-inclusion/pull/69*](https://github.com/badging/event-diversity-and-inclusion/pull/69)
+          - [*https://github.com/badging/event-diversity-and-inclusion/pull/70*](https://github.com/badging/event-diversity-and-inclusion/pull/70)
+          - [*https://github.com/badging/event-diversity-and-inclusion/pull/71*](https://github.com/badging/event-diversity-and-inclusion/pull/71)
+          - [*https://github.com/badging/diversity-and-inclusion/pull/12*](https://github.com/badging/diversity-and-inclusion/pull/12)
+          - [*https://github.com/chaoss/website/pull/577*](https://github.com/chaoss/website/pull/577)
+          - Review process deadline extended until April 14 to allow any
+            last-second feedback
+
+  - D\&I -----\> DEI Update 
+    
+      - > In progress
+    
+      - > On an “As I See” basis
+
+  - **Submit to OSSEU - **[***CFP
+    link***](https://events.linuxfoundation.org/open-source-summit-europe/program/cfp/)**
+    deadline is June 13**
+    
+      - > Nicole and Ruth and Matt S. 
+    
+      - > AI Nicole, Ruth, Matt S Put together a rough idea in a doc
+    
+      - > Matt S will not be available for this until June 1
+    
+      - > **Topic: Badging Initiatives **
+        
+          - What we learned increating the backing initiative
+          - Connecting the metrics to the workflow
+          - Accommodating all kinds of different submissions
+
+  - Metrics
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+    
+      - > Code of Conduct Enforcement
+        
+          - Code of Conduct at Project
+          - Code of Conduct at Event
+
+  - New Metric
+    
+      - > Travel support? DEI Support for speakers? 
+
+<span id="anchor-28"></span>March 31, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  -  Ruth Ikegah - Been Skipping today
+  -  Matt Snell - So excited\!
+  -  Elizabeth Barron - it’s freezing here today\! Only a high of 37
+    tomorrow 😭
+  -  Matt Germonprez - New Gardening Stuff\!\! 
+  -  Nicole Huesman -- feeling great, looking forward to gardening\!
+  -  Seunfunmi Adegoke - S.Pri Noir (Juste pour voir)
+
+Agenda:
+
+  - Facilitator Next Week: Sean Goggins 
+
+  - Badging -- Massive influx of applications 
+    
+      - > https://github.com/badging/event-diversity-and-inclusion/issues
+    
+      - > All stemming from Kubecon 
+    
+      - > Reviewers to help? 
+        
+          - Yes\! 
+          - Matt S. is setting up a review orientation
+          - No more than two reviews
+    
+      - > Some of the issues may take some time to work through. 
+        
+          - Maybe some comment about if you have a large number of
+            events, that you first submit only a few to work your way
+            through. 
+          - Also, ask if there is a team that can help out with the
+            response to comments in the issues. 
+          - AI: Matt S to reach out and encourage the team of event
+            planners to help respond to issue comments 
+          - AI: Matt S to reach out to reviewers to lend a hand
+    
+      - > Is there a way that they could submit a framework to help the
+        > review process? 
+        
+          - For example, is CoC accessible 
+    
+      - > How do we ensure consistency between reviewers??
+        
+          - AI: Matt S and ?? to look across reviewers to help with
+            consistency 
+          - Would it be worth, in this case, to build a spreadsheet to
+            track across the 11? 
+          - AI Matt & Matt: Look across reviews to ensure requests are
+            consistent & create a spreadsheet to track
+    
+      - > Should we also be recommending events that are going through
+        > the process not only be recognized for their DEI work, but
+        > also providing
+    
+      - >  additional visibility through CHAOSS channels as an event. 
+        
+          - Where do they start? 
+          - [*https://chaoss.community/diversity-and-inclusion-badging/*](https://chaoss.community/diversity-and-inclusion-badging/)
+            
+    
+      - > Organizational Application
+        
+          - Just one application with many event sites. 
+
+  - README Update 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/357*](https://github.com/chaoss/wg-diversity-inclusion/pull/357)
+        > 
+
+  - 
+
+<span id="anchor-29"></span>March 24, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Germonprez - 
+  - Beth Hancock - First vaccine today
+  - Seunfunmi Adegoke---- listening to Ruger
+  - Dawn Foster - excited about taking next week off 🎉
+  - Matt Snell - The word of the day is numpad
+  - J.W.F. — Feeling good, getting ready for my first break off in 2021
+    this week\!
+  - Stefka Dimitrova - enjoying the snow view from my window
+  - Ruth Ikegah - Totally skipped on this meeting today\! 
+
+Agenda:
+
+  - Updating for DEI (from D\&I)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/354*](https://github.com/chaoss/wg-diversity-inclusion/pull/354)
+    
+      - > Made me (Matt G) realize that we need to update all READMEs
+
+  - Updating Speaker Demographics based on prior discussion 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/353*](https://github.com/chaoss/wg-diversity-inclusion/pull/353)
+        > 
+    
+      - > “Keynote, track, and sessions selection committees are
+        > themselves diverse”
+        
+          - Please put this out for review. -- Something on the website
+            to describe the process. 
+    
+      - > Update to include “Diversity is present throughout the
+        > conference” 
+        
+          - Please put this out for review - Statement on website that
+            recognizes this as an important issue for the conference. 
+
+  - Badging 
+    
+      - > New Gold Badge for Berlin Buzzwords 😎
+    
+      - > THANK YOU\!\!
+    
+      - > [*https://2021.berlinbuzzwords.de/*](https://2021.berlinbuzzwords.de/)
+        > 
+    
+      - > [*https://github.com/badging/event-diversity-and-inclusion*](https://github.com/badging/event-diversity-and-inclusion)
+        > 
+        
+          - Need to issue a PR to include this event in the list 
+            
+              - > Waiting for their OKAY. 
+    
+      - > AI Matt S --- Reach out to Kevin to update the Reviewers List
+        
+          - We need to get this as a table and a thank you for reviewers
+    
+      - > Matt G is getting things like stickers that we can send to
+        > folks to thank them for their review work. 
+
+  - Diversity as regards bandwidth for conferences
+    
+      - > [*https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC\_wEJ-2UfU/edit*](https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC_wEJ-2UfU/edit)
+    
+      - > In the spreadsheet:
+        > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+    
+      - > Tag in the issue? 
+
+  - Self reflection 
+    
+      - > Website thoughts? 
+
+![](Pictures/10000000000009C4000000BC70922041785E6E88.png)
+
+  - > Move donate under community/participate -- DEI as top level? 
+
+  - > Ask Kevin for a User Experience Review -- a more thoughtful review
+    > of the layout on the page. 
+    
+      - Are their consulting companies that do this? 
+      - Web content / user experience 
+
+  - > AI: Matt G to find out of there are consulting groups that could
+    > help us.
+
+  - > Beth will touch base with Emily to see if she has time to re-UX/UI
+    > the CHAOSS site (and badging?). Emily can contact Matt G as well. 
+
+  - > Badging is considering applying to [*She Code
+    > Africa*](https://sites.google.com/shecodeafrica.org/contributhon/home/guide?authuser=0)
+    > contributhon.
+    
+      - Matt S: We want to use the same avenue as CHAOSS
+
+<!-- end list -->
+
+  - FSF issue 
+    
+      - > Email board list 
+    
+      - > AI: Matt G will reach out to Nicole and Georg 
+        
+          - Can we even do this with respect to LF. 
+
+  - 
+
+<span id="anchor-30"></span>March 17, 2021 🍀
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Germonprez - Super cold 
+  - Elizabeth Barron - hellooo
+  - Dawn Foster - all the trees are blooming here - feeling sneezy 
+  - J.W.F. – ready to curl up with a book and coffee on this rainy day…
+    if only.
+  - Matt Snell - ok boomer
+  - Seunfunmi Adegoke - a little pumped 
+  - Amy Marrich - Eating breakfast since time change
+  - Nicole Huesman -- sunny in the Pacific Northwest\!
+
+Agenda:
+
+  - CHAOSS D\&I Reflection. Two people have agreed 
+    
+      - > Building out the necessary technology and infrastructure 
+    
+      - > Notes:
+        > [*https://j.jwf.io/chaoss-divinc2021*](https://j.jwf.io/chaoss-divinc2021)
+        > 
+    
+      - > We are working with Kevin to ensure how this can be best
+        > displayed on the chaoss.community website. 
+
+  - Facilitator next week: Matt Germonprez 
+
+  - Diversity as regards bandwidth for conferences
+    
+      - > [*https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC\_wEJ-2UfU/edit*](https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC_wEJ-2UfU/edit)
+    
+      - > In the spreadsheet:
+        > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+
+  - Badging -- is there an open request that could use a bit of
+    encouragement?
+    
+      - > AI Matt S --- Reach out to Kevin to update the Reviewers List
+
+<!-- end list -->
+
+  - Update Speaker Demographics Metric to include an explicit focus on
+    the processes by which keynote (invited) speakers are identified. 
+    
+      - > This should also update to the Badging Program
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/speaker-demographics.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/speaker-demographics.md)
+        > 
+    
+      - > Composition of the pool of people who are selecting the
+        > keynote speakers as well as conference tracks and sessions 
+    
+      - > Describe how the selection process ensures that the
+        > implementation is not simply a signal of DEI
+    
+      - > Is the amount of new speakers important as well? We mentioned
+        > repeat speakers
+    
+      - > AI Matt Germonprez: Update the Speaker Demographics metric for
+        > a PR
+
+  - Changing to DEI: 
+    
+      - > AI Matt G to do this
+
+<span id="anchor-31"></span>March 10, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Elizabeth Barron - running late with everything today 
+  - Dawn Foster 😴
+  - Ruth Ikegah- Anxiety level up
+  - Matt Snell - Relaxed and happy
+  - Emily Brown - Feeling great
+  - J.W.F. — In a new co-working space, so different from home\!
+
+Agenda:
+
+  - Repo Management 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+    
+      - > Simply making sure that our released metrics line up with the
+        > repo. 
+    
+      - > AI LW: Matt G make sure things are all aligned across repo,
+        > website, and spreadsheet
+
+  - CHAOSS D\&I Reflection
+    
+      - > JWF has come on board as an internal/external expert
+    
+      - > Next few weeks:
+        
+          - Pretty good update by April 1
+
+  - Badging 
+    
+      - > Badge graphic was having some trouble being rendered in WP
+        
+          - New badges to come
+    
+      - > **Submit to OSSEU - **[***CFP
+        > link***](https://events.linuxfoundation.org/open-source-summit-europe/program/cfp/)**
+        > deadline is June 13**
+        
+          - Nicole and Ruth and Matt S. 
+          - AI Nicole, Ruth, Matt S Put together a rough idea in a doc
+    
+      - > Amy and Nicole may volunteer as reviewers
+    
+      - > AI Matt Snell - Reach out as CHAOSS Badging to Amy and Nicole
+
+  - Metric idea? Diversity as regards bandwidth for conferences
+    
+      - > Ideas on measuring:
+        
+          - Bandwidth options by platform
+          - Pre-recording experience
+          - Idea that women & people from underrepresented backgrounds
+            may need to have even better presentations than other
+            people, which can take more time to prepare.
+    
+      - > Idea: Rename Event Diversity to ….?
+    
+      - > AI Ruth:[* Create a Doc for Bandwidth
+        > Inclusion*](https://docs.google.com/document/d/1Y1jLiAfhmzwRef3RENwdOrev2s9NK2b3pC_wEJ-2UfU/edit?usp=sharing)
+        > (https://github.com/chaoss/metrics/blob/master/resources/metrics-template.md)
+
+  - Any updates on the next CHAOSScon?
+    
+      - > Originally did not want to create a virtual event
+    
+      - > Might be worth bringing up again
+    
+      - > Bring up in CHAOSS Weekly (Next Tuesday)
+
+<span id="anchor-32"></span>March 3, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  -  Matt Germonprez - The sun is amazing
+  -  Amy Marrich - Enjoying breakfast
+  -  Nicole Huesman -- Puppies on the brain\!
+  -  Anita Ihuman- weather is abnormally hot.
+  -  \[late\!\] Justin W. Flory — Catching up after a very busy end of
+    February\! (is it really March??)
+
+Agenda:
+
+  - Final review of D\&I metrics per the release 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/328*](https://github.com/chaoss/wg-diversity-inclusion/issues/328)
+        
+          - Matt will merge 
+        
+          - Change to 
+            
+              - > Chat Platforms / Chat Rooms / Groups 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/321*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+        
+          - Merged and done 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+        
+          - Done (I think) 
+          - Will take comments to a V2 in the future and/or a new metric
+            
+
+  - Repo Management 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+    
+      - > Simply making sure that our released metrics line up with the
+        > repo. 
+    
+      - > AI: Matt G make sure things are all aligned across repo,
+        > website, and spreadsheet 
+
+  - CHAOSS D\&I Reflection
+    
+      - > Do people have ideas on suggestions we might have to the team
+        > as to how to present the final results as both
+        
+          - Tractable to the CHAOSS project
+            
+              - > PDF 
+            
+              - > Presenting results at CHAOSScon
+            
+              - > What we found and what we are doing about it
+        
+          - Tractable to other projects
+            
+              - > Make internal PDF available 
+            
+              - > Presenting results at OSSNA/EU or other more global
+                > conferences 
+                
+                  - PyCon
+                  - OpenInfra
+                  - Conferences open to less technical discussions 
+            
+              - > Create an operational toolkit to help other projects
+                > perform a D\&I audit (based on CHAOSS audit)
+                
+                  - [*Data Deto x
+                    Kit*](https://www.datadetoxkit.org/en/home): Example
+                    format of documented, step-by-step “info toolkit”
+            
+              - > Training / Grants / Conference Workshops 
+            
+              - > **Proposal for OSSEU? **
+                
+                  - Sometime in June
+                  - This proposal could simply talk about what we are
+                    trying to do. 
+                  - How to collect metrics/toolkit.
+                  - Who we are and what we do?
+                  - Offer training?
+
+  - Badging 
+    
+      - > New submission (Berlin Buzzwords) on March 3rd 
+    
+      - > Badge graphic was having some trouble being rendered in WP
+    
+      - > **Submit to OSSEU **
+        
+          - **Nicole and Matt S. **
+    
+      - > Amy and Nicole may volunteer as reviewers 
+
+  - New Metric: Onboarding 
+    
+      - > [*https://docs.google.com/document/d/14g5WIFAvzWmxINZC\_Sr1fRCol6VWv169ATO\_xBVvim8/edit?usp=sharing*](https://docs.google.com/document/d/14g5WIFAvzWmxINZC_Sr1fRCol6VWv169ATO_xBVvim8/edit?usp=sharing)
+        > 
+        
+          - Onboarding at Events
+            
+              - > Coaching // Mentoring Speakers and Attendees
+            
+              - > Friendly Faces 
+            
+              - > How to pick what you want to see
+            
+              - > The importance of a hallway track 
+            
+              - > Newcomer welcome breakfast 
+            
+              - > Tour of the city 
+            
+              - > Morning yoga 
+            
+              - > 
+        
+          - Onboarding into a Project
+            
+              - > Lead in a way to bring people into the community 
+            
+              - > New project trying to figure out how others can be
+                > involved 
+    
+      - > AI: Matt to create the two different metrics 
+
+  - OSSEU 
+    
+      - > CHAOSS 
+    
+      - > Meet the CHAOSS project panel?
+        
+          - Different WGs and moderator
+          - Connect with Elizabeth on this 
+          - Bring this to the Community Call 
+
+<span id="anchor-33"></span>February 24, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Elizabeth Barron - hi\! 
+  - Emily Brown - Feeling great 
+  - Matt Snell - Happy to be here
+  - Sean Goggins 
+
+Agenda:
+
+  - Facilitator Next Week is… Matt Snell
+
+  - Technical Improvements to D\&I Badging by Matt Snell
+    
+      - > Moving to different cloud-based hosting service that’s easier
+        > to manage
+    
+      - > Bot will be able to determine if a new issue is for a review
+        > or just an issue
+    
+      - > Badge reviewers have been randomly assigned but we are
+        > implementing a new system based on how many reviews people
+        > have done and assign them that way
+
+  - Outreachy: We aren’t able to participate because we don’t have the
+    funds and we probably don’t qualify as a “humanitarian” project ;)
+    https://www.outreachy.org/docs/community/\#outreachy-general-fund
+
+  - GSOD: We are going to apply to participate for Augur, GL, and CHAOSS
+    Community (website work)
+
+  - Nicole Huesman brings up Social Tiles and volunteers to work on this
+    for us, yay\! 
+
+<span id="anchor-34"></span>February 17, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Lawrence Hecht ;)
+  - J.W.F. — Some Wednesdays this will be my first meeting, others it is
+    my fourth. Today is the latter.
+  - Sean Goggins, Snowy, Cold, and better off than Texas\!
+  - Matt Germonprez - Doing all right. 
+  - Matt Snell - Having such a good time, having a ball
+  - Ruth Ikegah - Having my first interview next week for a community
+    role, Tips??
+  - Amy Marrich - Sorry I was late\!
+  - Elizabeth Barron 
+  -  Anita Ihuman- sorry i was late
+  - Dhruv Sachdev
+
+Agenda:
+
+  - Facilitator for Next Week: Elizabeth Barron 
+
+  - D\&I Badging -- We really need to recruit and train reviewers 
+    
+      - > How can we incentivize and thank reviewers? 
+        
+          - Matt S., Elizabeth, and Matt G. will coordinate to get small
+            gifts to reviewers. 
+        
+          - ***SERIOUS***
+        
+          - Current Reviewers 
+            
+              - > Ruth Ikegah 
+            
+              - > Neofytos Kolokotronis 
+            
+              - > Anita Ihuman
+            
+              - > Dustin Mitchell
+            
+              - > Vinodh Ilangovan 
+            
+              - > Matt Germonprez
+            
+              - > More on the way\!
+        
+          - Perhaps more direct review outreach from
+            
+              - > Women who Code (local chapters)
+            
+              - > Girl Develop It (local chapters)
+            
+              - > Women in Technology
+                > ([*https://www.womenintechnology.org/*](https://www.womenintechnology.org/))
+            
+              - > Blacks in Technology (local chapters)
+            
+              - > ACM-W
+                > ([*https://women.acm.org/*](https://women.acm.org/))
+        
+          - Documenting FAQs from these conversations in on-boarding
+            calls would be helpful too
+        
+          - So we can capture the great work done by mentors and
+            organizers
+    
+      - > Fifth request is in:
+        > [*https://openjsf.org/openjs-world-2021/*](https://openjsf.org/openjs-world-2021/)
+        > 
+    
+      - > **[*https://svgshare.com/s/U6G*](https://svgshare.com/s/U6G)
+
+  - D\&I Reflection in the CHAOSS project 
+    
+      - > Thanks to Justin Flory who is going to serve as the liaison
+        > between CHAOSS and external reviewers 
+        
+          - Next step is to identify who the external reviewers are 
+
+  - Metrics comment period / review 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/328*](https://github.com/chaoss/wg-diversity-inclusion/issues/328)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/321*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+        
+          - Matt G. Will issue a PR on this
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+
+  - New Metric: Onboarding
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/348*](https://github.com/chaoss/wg-diversity-inclusion/issues/348)
+        > 
+
+**- Is CHAOSS participating in Outreachy or GSOD this year?**
+
+![](Pictures/100002010000022E0000015620CEC0D4CBC7721B.png)
+
+![](Pictures/100002010000024E00000136547614AF1E468957.png)
+
+<span id="anchor-35"></span>February 10, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Georg Link - Feeling excited about interesting conversations I’ve
+    been having.
+  - J.W.F. – Enjoying a lighter week after a more intense week\!
+  - Matt Germonprez - Mailman is on the loose. 
+  - Matt Snell - I’m here for now in spirit\! (Will be a tad late)
+  - Jim St. Leger - should be Friday...feels like a perpetual Monday
+  - Elizabeth Barron - buried in snow
+  - Ruth Ikegah - Sober, lost my mom this day 2 years ago 
+
+Agenda:
+
+  - Facilitator: Everyone\!?\!
+    
+      - > Project Burnout -- two very similar PRs
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/pull/347/files*](https://github.com/chaoss/wg-diversity-inclusion/pull/347/files)
+            
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/pull/343/files*](https://github.com/chaoss/wg-diversity-inclusion/pull/343/files)
+            
+              - > Add trace data section as one PR
+            
+              - > Editing the collection strategies as a series of PRs 
+            
+              - > Close original PR after new PRs are issued 
+            
+              - > No need to rush for the release 
+    
+      - > D\&I Badging Event Badging
+        
+          - [*https://chaoss.community/diversity-and-inclusion-badging/*](https://chaoss.community/diversity-and-inclusion-badging/)
+            
+        
+          - Outreach 
+        
+          - Armstrong -- Paper accepted regarding mentorship 
+            
+              - > [*https://conf.researchr.org/details/icse-2021/icse-2021-papers/119/Onboarding-vs-Diversity-Productivity-and-Quality-Empirical-Study-of-the-OpenStac*](https://conf.researchr.org/details/icse-2021/icse-2021-papers/119/Onboarding-vs-Diversity-Productivity-and-Quality-Empirical-Study-of-the-OpenStac)
+    
+      - > Possible Metrics to Work on in D\&I WG
+    
+      - > 
+
+<!-- end list -->
+
+  - [*Maintainability: Clean and Clear
+    Code*](https://github.com/chaoss/wg-diversity-inclusion/issues/74)
+  - [*Communication Inclusivity:
+    Alternative*](https://github.com/chaoss/wg-diversity-inclusion/issues/109)
+  - [*Diversity in Delivery of Talk
+    material*](https://github.com/chaoss/wg-diversity-inclusion/issues/240)
+  - Documentation Part 3: Zany Jamboree
+  - Onboarding 
+
+  - We’ll discuss the onboarding metric in next meeting.
+
+***Mentoring:***  
+Link to Linux Foundation Mentoring program.
+[*https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program*](https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program)
+
+**LF Expanded Mentorship Program:**
+
+Some slides from Shuah Khan, LF Fellow.
+[*https://wiki.lfedge.org/pages/viewpage.action?pageId=1671298\&preview=/1671298/29894302/LF%20Edge%20TAC%2009.09.2020%20final.pdf\#TechnicalAdvisoryCouncil(TAC)-PreviousTACCalls-MeetingSlidesandRecordings*](https://wiki.lfedge.org/pages/viewpage.action?pageId=1671298&preview=/1671298/29894302/LF%20Edge%20TAC%2009.09.2020%20final.pdf#TechnicalAdvisoryCouncil\(TAC\)-PreviousTACCalls-MeetingSlidesandRecordings)
+
+The LF Edge, **Open Horizon** program had great success with creating
+and running a mentoring program based on the LF Mentorship program. See
+details:
+[*https://mentorship.lfx.linuxfoundation.org/project/52faa755-1d30-4692-9796-e6bef09fa236*](https://mentorship.lfx.linuxfoundation.org/project/52faa755-1d30-4692-9796-e6bef09fa236)
+
+Open Horizon also published details on their mentorship process
+[*https://www.lfedge.org/2021/01/12/open-horizon-mentorships-with-lfx/*](https://www.lfedge.org/2021/01/12/open-horizon-mentorships-with-lfx/)
+and had one of their mentees Anukriti Jain share their experience in the
+program.
+[*https://mentorship.lfx.linuxfoundation.org/mentee/78d906d2-558b-4215-899e-cdd9c3c2a08a,52faa755-1d30-4692-9796-e6bef09fa236*](https://mentorship.lfx.linuxfoundation.org/mentee/78d906d2-558b-4215-899e-cdd9c3c2a08a,52faa755-1d30-4692-9796-e6bef09fa236)
+
+Fedora Join SIG, a group of mentors to help on-board new contributors
+into the community:
+[*https://docs.fedoraproject.org/en-US/fedora-join/*](https://docs.fedoraproject.org/en-US/fedora-join/)
+
+<span id="anchor-36"></span>February 3, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Snell - So glad to be here\!
+  - Emily Brown Happy Tuesday
+  - Ruth Ikegah - Looking for an entry role or internship :)
+  - Elizabeth Barron - I am definitely cold
+  - Matt Germonprez - I think I might be cold
+  - Nicole Huemsan - glad to be here\!
+  - Amy Marrich - I’ve got coffee - sends coffee through the net to
+    J.F.W.:)
+  - J.W.F. — yaaaaaawn   ^ share a cup with me? :D
+  - Georg Link - Happy to be here with you all.
+
+Notes: 
+
+  - Facilitator: Everyone\!?\!
+
+  - Changing to DEI
+    
+      - > Just want to make sure the acronym doesn’t represent something
+        > we don’t want it to
+    
+      - > Taking inventory of all the places we write “D\&I WG” and
+        > updating our labeling consistently
+        
+          - Update our Repo URL?
+            [*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+            
+    
+      - > IDEA - Inclusion, Diversity, Equity, and Access(ibility)
+    
+      - > Equity is the process of ensuring that processes and programs
+        > are impartial, fair and provide equal possible outcomes for
+        > every individual. “Equity is why we go to work,” explains
+        > Colman. “We want to get compensated fairly for our work, we
+        > want to be challenged, to learn and to contribute. People
+        > often choose an employer based on those things, which boil
+        > down to equity.”
+    
+      - > Signaling to the community that we care about “everything in
+        > the name + more”
+    
+      - > **AI: Matt G** to check on Legal issues for changing the name
+        > (if any) and repercussions of name changes (how much work
+        > would it be?)
+    
+      - > **How are we going to request consensus?**
+        
+          - Mailing list?
+          - Do we need a vote?
+          - Is there an option not to change it?
+
+  - Third gold badge [*awarded to
+    cdCon*](https://github.com/badging/event-diversity-and-inclusion)\!
+    
+      - > Need more reviewers at this pace
+    
+      - > **AI: **[*Matt Snell*](mailto:msnell@unomaha.edu)Reach out to
+        > RB at LF
+    
+      - > AI: Elizabeth add volunteer opportunity to the Newsletter and
+        > Twitter, also tweet about the newest badge
+
+> 
+
+  - Review and clear out [*issues on D\&I
+    repository*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    
+      - > Possible Metrics to Work on in D\&I WG
+
+<!-- end list -->
+
+  - [*Maintainability: Clean and Clear
+    Code*](https://github.com/chaoss/wg-diversity-inclusion/issues/74)
+  - [*Communication Inclusivity:
+    Alternative*](https://github.com/chaoss/wg-diversity-inclusion/issues/109)
+  - [*Diversity in Delivery of Talk
+    material*](https://github.com/chaoss/wg-diversity-inclusion/issues/240)
+
+  - Metrics Toolkit
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/252*](https://github.com/chaoss/wg-diversity-inclusion/issues/252)
+    
+      - > [*https://toolkit.mozilla.org/methods/*](https://toolkit.mozilla.org/methods/)
+        > 
+    
+      - > This is the idea for our external review
+
+  - Miscellanea
+    
+      - > Are we able to request an invite to the CHAOSS GH org?
+        > [*https://github.com/chaoss*](https://github.com/chaoss) 
+    
+      - > [*https://github.com/jwflory/*](https://github.com/jwflory/) 
+
+<span id="anchor-37"></span>January 27, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  -  Vinod Ahuja
+  -  Dawn Foster 🍵
+  -  Ruth Ikegah - Feels good to be back, coming out of burnout :(
+  -  Matt Germonprez - Border collies are great if you love dog hair
+  -  Elizabeth Barron 🥶
+  - 
+  -  Matt Snell - Still Waking Up\!\!
+  - Stefka Dimitrova - better always late than not participating at all
+    :)
+
+Notes: 
+
+  - Facilitator: Matt Snell
+
+  - Facilitator Next Week: Committee Facilitation
+
+  - Review document relocation and consolidation efforts (Elizabeth and
+    Matt S.)
+    
+      - > Created a Google CHAOSS account
+    
+      - > We have a central place to put the docs
+        
+          - **AI: Elizabeth **-- Needs to be shared with Matt Snell 
+        
+          - Archived Meeting Minutes here:
+            [*https://drive.google.com/drive/folders/17Q\_WsdgGm\_54ssEvzvNnd6WyQ1zHOlHo?usp=sharing*](https://drive.google.com/drive/folders/17Q_WsdgGm_54ssEvzvNnd6WyQ1zHOlHo?usp=sharing)
+            
+              - > Put them as new docs 
+            
+              - > Put them in as markdown as well
+                
+                  - This isn’t clear to me as to whether or not we have
+                    a single archive folder or we have a folder in each
+                    working group that holds archived minutes 
+
+  - D\&I self reflection activities
+    
+      - > Rebranding to DEI
+        
+          - YES\!
+          - Start with the forward (web facing), README, Meeting
+            invites, etc.
+          - Do we need a new focus area to accommodate it? 
+    
+      - > Form of outreach: Social media?Internal capture
+        
+          - One person to provide orientation and information
+    
+      - > External capture
+        
+          - Identifying potential consultants
+    
+      - > How to present the work
+        
+          - Matt G has ideas
+
+  - Status of Burnout Submission 
+
+  - D\&I Badging 
+    
+      - > Excellent process on the most recent bading effort 
+    
+      - > FOSDEM Organizing Team 
+        
+          - It may be tricky with the lack of time
+    
+      - > Think about prioritizing events that have more immediate needs
+        > of conferences 
+        
+          - We have to be realistic about how many reviews we can handle
+            in a given point in time
+
+  - Housekeeping: Dead link in Calendar Invite
+
+<span id="anchor-38"></span>January 20, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Amy Marrich - it’s cold today\!
+  - Sean Goggins - Today is the first day of the rest of 2021
+  - Armstrong Foundjem 
+  - Emily Brown - Inauguration Day\!\! Woohoo\!
+  - Vinod Ahuja
+  - Elizabeth Barron - breathing a sigh of relief today
+  - Kevin Lumbard
+  - Matt Snell - Feeling Good
+
+Notes:
+
+  - Facilitator this week: Sean Goggins
+
+  - Discussion of archiving old document
+    
+      - > \[AI: EB to create a CHAOSS Google Account, and a shared
+        > folder for meeting minute archival note for all working
+        > groups.\]
+    
+      - > \[AI: Matt Snell is going work on converting the archive to
+        > Markdown ensuring the preservation of indentation and graphic
+        > fidelity.\]
+    
+      - > \[AI: The community will archive the previous year on March 1
+        > of every calendar year henceforth to the end of time. \]
+
+  - Stop at 30? (Yes)
+    
+      - > Inauguration...
+
+  - CHAOSS D\&I Self-reflection (Context: Self examination of the CHAOSS
+    project through a Ford Foundation grant. Focused especially on
+    D\&I).
+    
+      - > How to capture the work 
+        
+          - Who might those people be? The people who would be paid
+            outsiders to facilitate analysis and community reflection. 
+            
+              - > How to identify?
+                
+                  - Internal/External 
+                  - External as possible 
+                  - Internal can help facilitate 
+            
+              - > Form of outreach?
+            
+              - > Framing of what our goals are when asking for their
+                > involvement.
+                
+                  - Goal 1: Use our own metrics and identify metrics we
+                    are missing, or would benefit from refinement. 
+                  - Goal 2: How is CHAOSS doing with respect to D\&I? 
+                  - Goal 3: Build a roadmap for CHAOSS moving forward? 
+                  - Goal 4: Articulate the process so that others can do
+                    the same (CHAOSS initiative?) 
+        
+          - How do we capture the process through which that reflection
+            occurred from the outside without having to reinvent the
+            process. 
+            
+              - > Internal capture ++ 
+                
+                  - Documents
+                  - Processes
+                  - Artifacts
+            
+              - > External capture so others can do something similar
+                > without having to engage outside advisors. 
+    
+      - > How to present the work 
+
+  - GitHub Issues and PRs
+
+  - Translations
+    
+      - > [*https://github.com/chaoss/translations*](https://github.com/chaoss/translations)
+        > 
+
+<span id="anchor-39"></span>January 13, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Amy Marrich - 4th meeting in a row and second double booked one in a
+    row
+  - Georg Link - 🎄 still in Christmas mood 
+  - Justin J.W.F.. – Emerging from the new year holiday, and the crazy
+    week here in Georgia
+  - Emily Brown- feeling a little under the weather
+  - Elizabeth Barron 
+  - Tola Ore-Aruwaji 
+  - Matt Snell - Happy to be here\!
+  - Kevin Lumbard
+  - Sean Goggins
+
+Notes:
+
+  - Issues and PRs. 
+    
+      - > Maybe we could start to work a few of these down
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion*](https://github.com/chaoss/wg-diversity-inclusion)
+        > 
+    
+      - > We had an issue with PR 338 that it was based on an old
+        > version of the file. Asked original author to update or
+        > resubmit
+    
+      - > Looking at issue \#305, we discussed how to keep the metrics
+        > and templated metrics up to date and avoid duplication.
+        
+          - cleanup work: remove older files that we have newer metrics
+            for
+
+  - **AI Georg and Justin:** Try out GitHub Project board for better
+    managing D\&I issues.
+    
+      - > [*https://jwflory.gitlab.io/heuristics/project-management/project-boards/*](https://jwflory.gitlab.io/heuristics/project-management/project-boards/)
+        > 
+    
+      - > [*https://opensource.com/article/18/4/keep-your-project-organized-git-repo*](https://opensource.com/article/18/4/keep-your-project-organized-git-repo)
+        > 
+
+  - Translations
+    
+      - > [*https://github.com/chaoss/translations*](https://github.com/chaoss/translations)
+        > 
+
+  - CHAOSS D\&I Self-reflection 
+    
+      - > How to capture the work 
+    
+      - > How to present the work 
+
+  - Facilitator next week: Sean Goggins
+
+<span id="anchor-40"></span>January 6, 2021
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Elizabeth Barron - feeling hopeful today
+  - Vinod Ahuja - Feeling energetic
+  - Matt Germonprez - DMV Success\!
+  - Emily Brown- feeling great
+  - Matt Snell - Just truly discovered figs\! They’re great\!
+  - Saleh Abdel Motaal — very confused to think of something 🤣 
+  - Amy Marrich - Chickens are noisy today
+  - Nicole Huesman - echoing Elizabeth, feeling hopeful :)
+  - Beth Hancock - Adding to the hope, but have to hop back off and fix
+    computer issues for school. Happy 2021\!
+  - Kevin Lumbard
+
+Video:
+
+Notes:
+
+  - Welcome Back\!
+
+  - Language Diversity
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/339*](https://github.com/chaoss/wg-diversity-inclusion/issues/339)
+
+  - Goal Setting
+    
+      - > Short term
+        
+          - Translations - into Chinese and Spanish
+            
+              - > Building a process to get community support
+        
+          - Outreachy
+            
+              - > Cannot financially support
+            
+              - > Still - Go through the process of how that looks for
+                > CHAOSS
+        
+          - GSoC
+            
+              - > Org Application Period Jan 29 - Feb 19
+    
+      - > Badging Goals for Year 2021
+        
+          - Project badging
+        
+          - Updating bots and optimizing workflow
+        
+          - Virtual Events - revising/adding metrics and how things are
+            worded out
+            
+              - > Adding more inclusion metrics
+        
+          - Something else?
+        
+          - Question: Do we need a design perspective?
+    
+      - > Diversity and Inclusion Review of CHAOSS
+    
+      - > Long term
+        
+          - Getting the word out
+            
+              - > Nicole H, Elizabeth B, Probably Emily B?, Possibly Amy
+                > M?
+            
+              - > Possibly: Making a report for the OSS Community
+        
+          - Work on any issues that are found by external resources
+            
+              - > Ford foundation asked us to take a look at our D\&I
+
+  - Issues and PRs. 
+    
+      - > Maybe we could start to work a few of these down
+
+<span id="anchor-41"></span>
+
+<span id="anchor-42"></span>December 16, 2020
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - 
+  - Elizabeth Barron - sorry I was late, exam week means weird times for
+    the kiddo pickup
+  - Matt Germonprez - Dealing with a stolen phone :(
+  - Georg Link - 
+  - Amy Marrich - Breakfast finished\!
+  - Emily Brown - feeling cold
+  - Matt Snell - Our dog is good at being sweet
+  - Beth Hancock - FEeling hopeful for 2021
+
+Video:
+
+Notes:
+
+  - AIs from last week:
+    
+      - > Chat Channels
+        
+          - **AI LW JWF:** move to a pull request to the D\&I WG repo.
+            
+              - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/327*](https://github.com/chaoss/wg-diversity-inclusion/pull/327)
+            
+              - > We merged this, fixed a few minor formatting issues
+        
+          - **AI LW Georg:** publish blog post on chaoss.community
+            
+              - > [*https://chaoss.community/blog-post/2020/12/15/di-metrics-definition/*](https://chaoss.community/blog-post/2020/12/15/di-metrics-definition/)
+    
+      - > **AI LW D\&I WG:** work on [*Documentation
+        > Discoverability*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit)
+        > this time
+        
+          - **AI:** Georg L and Matt G: Review in their own time
+
+  - 23rd and 30th canceled\!
+
+  - Next meeting on January 6, 2021
+
+<span id="anchor-43"></span>December 9, 2020
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Snell (facilitator) —
+  - Matt Germonprez - Double booked. D\&I wins\!
+  - Georg Link -- 🎄
+  - Beth Hancock - A day of recovery for me and helping my daughter
+    learn about responsibility 
+  - Ruth Ikegah - Doing okay, preparing a proposal for FOSDEM :)
+  - J.W.F. — Busy week this week before taking next week off\!
+  -  Elizabeth Barron - it’s finally a sunny day\!
+  - M
+
+Video:
+
+Notes:
+
+  - Review Issues, PR’s and Metrics for Release
+    
+      - > Working on metrics:
+        
+          - [*Chat Channel
+            Inclusivity*](https://docs.google.com/document/d/1JEiA1OTyXBCaexgK_zxSx6eIXfOAdbMHjqzho0hlHSY/edit)
+            (was: Public Chat Channels):
+            
+              - > **AI JFW:** move to a pull request to the D\&I WG
+                > repo.
+        
+          - We decided to publish the list of chat platforms on the
+            CHAOSS blog ([*2020-12-02 CHAOSS D\&I WG Blog Post: Pulling
+            metrics from Chat
+            Channels*](https://docs.google.com/document/d/1xJCCJluFS6sknChZup_hwFpGXO2AQ0defY70SR5TJ24/edit?usp=sharing))
+            
+              - > **AI Georg:** publish blog post on chaoss.community
+                
+                  - [*https://github.com/chaoss/website/pull/470*](https://github.com/chaoss/website/pull/470)
+        
+          - [*Documentation
+            Discoverability*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit)
+            
+              - > **AI D\&I WG:** work on this next time
+    
+      - > Metrics Under Review:
+        
+          - [*Documentation
+            Accessibility*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+          - [*Project
+            Burnout*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+    
+      - > D\&I Badging
+        
+          - First badge announcement\!
+
+  - Misc.
+    
+      - > J.W.F. — How is the badging program going? It would be great
+        > to hear an update\!
+        
+          - See above :) 
+
+<span id="anchor-44"></span>December 2, 2020
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - J.W.F. — This is my fourth meeting today. Phew\!
+  - Sean Goggins - New home office has power, and soon heat and doors\!
+  - Matt Snell - What kind of superhero hits the most home runs?
+  - Elizabeth Barron - 👩‍💻
+  - Kevin Lumbard
+  - Georg Link - 😊🎄
+  - Beth Hancock - coffee..coffee is my friend
+  - Amy Marrich - third for me I had a break and breakfast\!
+
+Video:
+
+Notes:
+
+  - Facilitator Next Week: Matt Snell
+
+  - Reply from Angela Brown from LF Events to our recommendations on the
+    dis/ability question on the registration forms:
+    
+      - > *“Thank you to you and the CHAOSS D\&I WG members for your
+        > efforts here which are much appreciated. We will put all of
+        > your recommendations in place, and the latter two will be
+        > reflected on all future registration forms.” -- *Angela Brown,
+        > Linux Foundation
+        
+          - The CHAOSS D\&I WG made the following recommendations:
+            
+              - > 1\. Ask for clarification on what seemed intrusive so
+                > we can better respond to it.
+            
+              - > 2\. Reframe the question around how we can accommodate
+                > people: Do you have a dis/ability we should be mindful
+                > of as we try to accommodate everyone?
+            
+              - > 3\. Group the question away from the demographic
+                > questions and with the other accommodation questions
+                > like about food intolerance.
+
+  - Review Issues, PR’s and Metrics for Release
+    
+      - > Working on metrics:
+        
+          - [*Public Chat
+            Channels*](https://docs.google.com/document/d/1JEiA1OTyXBCaexgK_zxSx6eIXfOAdbMHjqzho0hlHSY/edit)
+            (was: Communication Channels): Status: One final review in
+            this meeting next week, then hopefully release for review. 
+            
+              - > **AI J.W.F.**: incorporate feedback; 
+            
+              - > **AI D\&I WG:** review again next week for final
+                > touches and to start public comment period
+            
+              - > We decided to publish the list of chat platforms on
+                > the CHAOSS blog:
+                > [*https://docs.google.com/document/d/1xJCCJluFS6sknChZup\_hwFpGXO2AQ0defY70SR5TJ24/edit?usp=sharing*](https://docs.google.com/document/d/1xJCCJluFS6sknChZup_hwFpGXO2AQ0defY70SR5TJ24/edit?usp=sharing)
+                
+                  - **AI J.W.F.:** add a paragraph or two
+                  - **AI Georg:** finish and publish blog post
+        
+          - [*Documentation
+            Discoverability*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit)
+            
+              - > **AI D\&I WG:** work on this next week
+    
+      - > Metrics Under Review:
+        
+          - [*Documentation
+            Accessibility*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+          - [*Project
+            Burnout*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+
+<span id="anchor-45"></span>November 25, 2020 - Canceled for Turkey Day
+
+<span id="anchor-46"></span>
+
+<span id="anchor-47"></span>November 18, 2020 
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Georg Link - 👨‍👨‍👧‍👦
+  - Dawn Foster 
+  - Sean Goggins - 
+  - Elizabeth Barron - I have a leaky ceiling 💦😓
+  - Emily Brown- Feeling groovy
+  - J.W.F. — Calm, quiet, collected
+  - Matt Snell - Glad to be here :)
+  - Katie Schueths - It is cold, had to go get a jacket today
+  - Beth Hancock - Learning more
+  - Silona Bonewald - Caffeine is my bestie
+  - Amy Marrich - Bit chilly but warming up
+  - Nicole Huesman
+
+Video: 
+
+Notes: 
+
+  - Are all metrics that are in the continuous release cycle and have
+    passed their review period on the website and the spreadsheet? ---
+    the real question is whether there has been comments we need or want
+    to address -- the metric stays under review until our next release.
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/321*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+        > 
+    
+      - > Current Metrics Listed:
+        > [*https://chaoss.community/metrics/*](https://chaoss.community/metrics/)
+        > 
+    
+      - > Current Spreadsheet:
+        > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+
+> 
+
+  - 
+
+> 
+
+  - (J.W.F.) Communication Channels metric follow-up:
+    
+      - > Doc: [*Communication Channels - CHAOSS D\&I Metric
+        > (draft)*](https://docs.google.com/document/d/1JEiA1OTyXBCaexgK_zxSx6eIXfOAdbMHjqzho0hlHSY/edit?usp=sharing)
+    
+      - > Concept draft is ready for review. Could use help from WG with
+        > a group brainstorm on implementation and data collection
+        > strategies.
+    
+      - > Current Spreadsheet:
+        
+          - [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+            
+    
+      - > Significant edits during meeting.
+
+  - MozFest Spaces: 
+    
+      - > [*https://www.mozillafestival.org/en/uniquely-mozfest/spaces/*](https://www.mozillafestival.org/en/uniquely-mozfest/spaces/)
+    
+      - > Ruth and Matt G. 
+    
+      - > AI [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu): Connect
+        > with Ruth and Matt G
+
+  - If time, let’s get back to Documentation Discoverability: 
+    
+      - > [*https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit)
+        > 
+
+<span id="anchor-48"></span>
+
+<span id="anchor-49"></span>November 11, 2020 
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Ruth Ikegah - Long day, tired 
+  - Matt Germonprez - doing well. I feel like I’m catching up with a few
+    things :) 
+  - Sean Goggins - New Augur Release Yesterday\! 
+  - Matt Snell - Here to listen today :)
+  - Georg Link - Lots of things happening at once. 
+  - Beth Hancock - All the things\! :D
+  - Elizabeth Barron - hello\!
+  - Saleh Abdel Motaal — Happy to be here :) 
+  - J.W.F. — Tired. A little nervous to present my first metric draft
+    today\! (but a good kind of nervous)
+  - Silona Bonewald - Naughy kitty cats turning off sound
+  - Katie Schueths - Herding cats and dogs and enjoying the sunny day 
+  - Amy Marrich - I actually already had breakfast\!:)
+  - Vinod Ahuja - my pc crashed
+
+Video: We didn’t record the meeting.
+
+Notes: 
+
+  - Facilitator for Next Week: Sean Goggins 
+
+  - Recap of Action Items / Prior Discussions
+    
+      - > LF Survey Items
+        
+          - Complete? Responded? 
+          - **AI Georg:** respond to Angela Brown.
+          - We list “Dis/Abilities” in our Dimensions of Diversity and
+            Inclusion:
+            [*https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data*](https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data)
+            
+    
+      - > D\&I Badging 
+        
+          - Outreach 
+        
+          - Matt Snell 
+        
+          - D\&I Badging Program
+            
+              - > [*https://chaoss.community/diversity-and-inclusion-badging/*](https://chaoss.community/diversity-and-inclusion-badging/)
+                > 
+        
+          - Working to identify folks who may work to badge their events
+            
+              - > [*https://docs.google.com/spreadsheets/d/15Ewx9\_DGHzD49CH23qJ7kDlnBVUfW3rlsNIE49c3qrY/edit\#gid=0*](https://docs.google.com/spreadsheets/d/15Ewx9_DGHzD49CH23qJ7kDlnBVUfW3rlsNIE49c3qrY/edit#gid=0)
+                > 
+        
+          - Brunch document (aka mailing list pitch)
+            
+              - > [*https://docs.google.com/document/d/1hydd9kj1zV50nbY1uIsSDnmlyop9n7qeSYptqoRRFvo/edit?usp=sharing*](https://docs.google.com/document/d/1hydd9kj1zV50nbY1uIsSDnmlyop9n7qeSYptqoRRFvo/edit?usp=sharing)
+                > 
+
+  - Metrics Status
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+    
+      - > Could we move those that are under community review to final? 
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/321*](https://github.com/chaoss/wg-diversity-inclusion/issues/321)
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+            
+    
+      - > New metric idea: Project accessibility -- a way to survey
+        > community members
+
+  - (J.W.F.) Communication Channels metric follow-up:
+    
+      - > Doc: [*Communication Channels - CHAOSS D\&I Metric
+        > (draft)*](https://docs.google.com/document/d/1JEiA1OTyXBCaexgK_zxSx6eIXfOAdbMHjqzho0hlHSY/edit?usp=sharing)
+    
+      - > Concept draft is ready for review. Could use help from WG with
+        > a group brainstorm on implementation and data collection
+        > strategies.
+    
+      - > P.S. — Shout-out to Ruth and burnout metric editors, it helped
+        > to use as a base\!
+
+  - MozFest Spaces: 
+    
+      - > [*https://www.mozillafestival.org/en/uniquely-mozfest/spaces/*](https://www.mozillafestival.org/en/uniquely-mozfest/spaces/)
+
+  - Tangent: On Measuring Accessibility… etc. (5 minutes)
+
+<!-- end list -->
+
+  - Burnout metric:
+    [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit)
+
+<span id="anchor-50"></span>
+
+<span id="anchor-51"></span>November 4, 2020 – Canceled
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Ruth Ikegah -
+  -  Silona Bonewald - IEEE SA OPEN :-| Patience is a skill that needs
+    practicing?
+  -  Hi all :) I was on for a bit but didn’t see folks so I figured
+    there was not a meeting this week -- US Election? I hope you are all
+    doing well\! -- Matt G. 
+
+No problem Ruth. Let’s just pick this up when everyone is back next week
+:) I really do hope you are doing well and that things are improving :)
+You too :) \!\!
+
+Notes: 
+
+  - Facilitator for Next Week: 
+
+  - Recap of Action Items / Prior Discussions 
+    
+      - > LF Survey Item 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+    
+      - > D\&I Badging 
+        
+          - Outreach 
+
+  - Metrics Status
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+
+<span id="anchor-52"></span>October 28, 2020 – Canceled\!
+
+<span id="anchor-53"></span>
+
+<span id="anchor-54"></span>October 21, 2020
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Matt Snell - Missing half my curtains (Cat’s handiwork)
+  - Lawrence Hecht (figuring out what Central Time means)
+  - Ruth Ikegah - Traumatized :( , So much killing here in Nigeria
+  - Sean Goggins - PTTD (Post Traumatic Trump Disorder)
+  - Kevin Lumbard 
+  - Georg Link - Excited and nervous
+  - Justin/J.W.F. — How *am* I feeling? All excited, upset, happy,
+    frustrated.
+  - Elizabeth Barron 😔
+  - Tharun Ravuri - I am back after so many days.
+  - Nicole Huesman - love the changing of the colors in autumn, but the
+    dark mornings are a little tough\!
+  - Dawn Foster
+
+<span id="anchor-55"></span>Notes:
+
+  - Facilitator Next Week: 
+    
+      - > No meeting Oct 28
+    
+      - > Nov 4 (two weeks from now): J.W.F. can facilitate\!
+
+  - Evolution note: Code Reviews (i.e., Pull Requests) name changed to
+    **Change Requests**
+    
+      - > Check D\&I metrics for name consistency
+    
+      - > Evolution WG will scan all repos
+
+  -  Zoom link changing after November 1st
+    
+      - > New link will be shared
+    
+      - > Time zone change
+        
+          - To US Central Standard Time // America/Chicago
+
+  - Survey question designs
+    
+      - > Disability question
+        
+          - *\[Angela:\] I had a community member (he is involved in
+            several of our projects, and works at a member company)
+            reach out and tell me he thought our disability related
+            questions on our event registration forms were too
+            intrusive. I have explained why we collect the data and that
+            the questions are 100% optional, confidential and were part
+            of a list of recommended questions we received from the
+            CHAOSS workgroup, but I also told him I'd research this a
+            bit more. Would you mind asking the group what they think? A
+            screenshot of these questions is attached.*
+
+> ![](Pictures/1000020100000548000003F87B4C135DC4739A74.png)
+
+  -   -   -   - > \[Georg:\] The intention behind this question’s design
+                > was to empower people with multiple disabilities to
+                > tell you about all of them without feeling they are
+                > put in a collective box (a simple yes/no question -
+                > are you disabled) or in an insufficient category of
+                > only one disability (drop-down option - forcing a
+                > choice). Accommodating each disability type at an
+                > event requires different actions. I also understand
+                > that the resulting question format takes up a lot of
+                > space on the survey and that this can seem intrusive,
+                > compared to the other questions that take up less
+                > space on the screen.
+        
+          - Question: is the question about accommodating people or just
+            interesting to know that we have diversity at the event?
+            
+              - > Suggestion: 
+            
+              - > Provide better understanding of how the data will be
+                > used to survey-responder?
+            
+              - > Since the person sharing feedback was not specific
+                > about why it was intrusive, we have to assume their
+                > discomfort was from lack of understanding why this
+                > data is being collected.
+            
+              - > Separate out the “want to know diversity” questions
+                > from the “want to accommodate you” questions.
+            
+              - > Maybe remove the “as defined by the ADA” -- feels less
+                > intrusive like that.
+            
+              - > Maybe reword the questions: Do you have a disability
+                > we should be mindful as we try to accommodate
+                > everyone?
+            
+              - > It is not clear how people with disabilities have been
+                > accommodated. -- But the data is helpful to request
+                > funds to make special accommodations.
+                
+                  - Maybe instead of asking about their disability, ask
+                    which accommodations they would like to use.
+        
+          - The CHAOSS D\&I WG makes the following recommendations:
+            
+              - > 1\. Ask for clarification on what seemed intrusive so
+                > we can better respond to it.
+            
+              - > 2\. Reframe the question around how we can accommodate
+                > people: Do you have a dis/ability we should be mindful
+                > of as we try to accommodate everyone?
+            
+              - > 3\. Group the question away from the demographic
+                > questions and with the other accommodation questions
+                > like about food intolerance.
+        
+          - Matt S: Possibly provide a link to the statement at the top?
+
+  - Address Feedback on Release Candidate Comments (Project Burnout) 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+        > 
+    
+      - > Split out into 2+ metrics?
+    
+      - > Add in the metric language like “Sample questions can be:”
+    
+      - > We should add a disclaimer at the CHAOSS metrics level:
+        
+          - The CHAOSS metrics are like a menu you can pick and choose
+            from and even within metrics are ideas that can inform your
+            data collection but you don’t have to do it all.
+    
+      - > This is the disclaimer currently on the website
+        
+          - *\#\#\# Disclaimer*
+
+*Metrics on this page were debated in working groups and undergo a 30
+day comment period to ensure validity. Released metrics are only a
+subset of many possible metrics. CHAOSS acknowledges that more metrics
+exist and is working to identify and release new metrics in the future.
+If you would like to learn more about metrics, suggest new metrics, and
+or help define metrics please visit our \[participate
+page\](https://chaoss.community/participate/).  *
+
+*The CHAOSS project recognizes that there are ethical and legal
+challenges when using the metrics and software provided by the CHAOSS
+community. \*\*Ethical challenges\*\* exist around protecting community
+members and empowering them with their personal information. \*\*Legal
+challenges\*\* exist around GDPR and similar laws or regulations that
+protect personal information of community members. Particular challenges
+may arise in the use that is specific to your context.*
+
+  -   - > Maybe narrow down the list of questions to \~5 and clarify
+        > what hypothesis they are trying to test.
+        
+          - **AI Lawrence:** propose something async
+
+  - Badging:
+    
+      - > Outreach Track
+        
+          - Thanks for all the support everyone\! (from Matt)
+        
+          - First meeting is Tuesday 10/27
+            
+              - > 10AM CDT
+            
+              - > Lots to discuss, email
+                > [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu) to
+                > join
+    
+      - > Merging Badging documentation with Community Handbook (tabled
+        > for next week)
+        
+          - When do we start?
+          - How do we want to move it? I.e. Drafts
+
+<span id="anchor-56"></span>
+
+<span id="anchor-57"></span>October 14, 2020
+
+Attendees (please add yourself and let us know how you’re feeling today
+e.g., with an emoji):
+
+  - Georg Link - 🥴
+  - Dawn Foster (need to leave at half past) 🏃🏻‍♀️
+  - Matt Snell - Grateful
+  - Aastha - slightly sleepy :)
+  - Xiaoya - Happy to be here
+  - Amy Marich - breakfast\!
+  -  Ruth Ikegah - Depressed from a protest- police brutality :(
+
+Video: [*https://youtu.be/\_WtPbUSVK-c*](https://youtu.be/_WtPbUSVK-c) 
+
+Notes:
+
+  - Facilitator next week: Matt Snell
+
+  - Change of CHAOSS Zoom information on November 1
+
+  - Project Burnout
+    
+      - > PR to add the metric to our repo is:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/316*](https://github.com/chaoss/wg-diversity-inclusion/pull/316)
+    
+      - > Next steps:
+        
+          - Create an issue for comments (done\!)
+            
+              - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/319*](https://github.com/chaoss/wg-diversity-inclusion/issues/319)
+        
+          - Add metric to website (requires someone with website access)
+
+  - Advance Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1IKSELCPewXfYeCvfv-Fwyhac9pVTsdL8cP3A6KXp5j8/edit?usp=sharing*](https://docs.google.com/document/d/1IKSELCPewXfYeCvfv-Fwyhac9pVTsdL8cP3A6KXp5j8/edit?usp=sharing)
+        > 
+    
+      - > We 
+
+  - Badging Update
+    
+      - > Reaching out to events to invite them to submit for badges
+    
+      - > Get involved: [*msnell@unomaha.eduWill start regular meeting
+        > to organize outreach*](mailto:msnell@unomaha.edu)
+
+<span id="anchor-58"></span>October 7, 2020
+
+Attendees (Add your name and how you’re feeling today)
+
+  - MMatt Germonprez - Fine 
+  - Georg Link - 🥳 we bought land to build across the street from my
+    in-laws
+  - Dawn Foster - feeling snacky (I’ll mute while I eat nuts and apples)
+    :) 
+  - Matt Snell - Grateful
+  - Amy Marrich - need coffee\!
+  - Elizabeth Barron - on my 2nd cup 
+  - Sean Goggins - reelin’ in the years 
+  - Ruth Ikegah -- headaches :(
+  - Anita Ihuman - exhausted
+  - Justin/J.W.F. — Today is a pajama-bottoms kind of day.
+  - Stefka Dimitrova - inspired
+
+Video:
+
+Notes:
+
+  - Facilitator next week: Georg Link
+
+  - Change of CHAOSS Zoom information on November 1
+
+  - Badging Outreach 
+
+  - Translation starting for metrics pages
+    
+      - > Chinese - Mandarin
+    
+      - > Spanish - Madrid
+
+  - CHAOSS D\&I Reflection Work 
+    
+      - > Ford Foundation provides financial support to build team of
+        > external reviewers for the CHAOSS project
+        
+          - 4 external people who are not regular CHAOSS participants
+            
+              - > Search committee will be put together
+            
+              - > Want global representation
+        
+          - 1 CHAOSS liaison 
+        
+          - 1 student who can help document process and make work
+            available to others
+        
+          - If You are on this call and are interested in being part of
+            the “committee to select a committee”, please express
+            interest here: 
+            
+              - > Matt G
+            
+              - > Georg
+            
+              - > Sean G.
+            
+              - > Amy Marrich
+            
+              - > Matt S.
+            
+              - > 
+            
+              - >  
+    
+      - > Outcome:
+        
+          - Suggestions for CHAOSS project
+          - Document how other projects do the same
+
+  - Burnout
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit\#*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit#)
+        
+          - Georg is going to move this to GitHub 
+          - Thanks Georg and thanks Ruth\!\!
+    
+      - > PR to add the metric to our repo, Ruth is :
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/316*](https://github.com/chaoss/wg-diversity-inclusion/pull/316)
+
+  - New Metrics 
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+        
+          - Communication Inclusivity
+            
+              - > Listening
+            
+              - > Speaking 
+        
+          - Code of Conduct Enforcement 
+        
+          - Documentation Discoverability
+            
+              - > [*https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit?usp=sharing*](https://docs.google.com/document/d/17eJqz1DT4nRfZVmIB9FoupSRvvCiuyQqxhX48h1sghE/edit?usp=sharing)
+        
+          - Documentation Accessibility 
+            
+              - > [*https://docs.google.com/document/d/1IKSELCPewXfYeCvfv-Fwyhac9pVTsdL8cP3A6KXp5j8/edit?usp=sharing*](https://docs.google.com/document/d/1IKSELCPewXfYeCvfv-Fwyhac9pVTsdL8cP3A6KXp5j8/edit?usp=sharing)
+                > 
+
+  - Next Time 
+    
+      - > Move Documentation Accessibility forward
+        
+          - Track down the prior comment 
+          - Workshop next week 
+    
+      - > Template: 
+        
+          - [*https://github.com/chaoss/metrics/blob/master/resources/metrics-template.md*](https://github.com/chaoss/metrics/blob/master/resources/metrics-template.md)
+            
+
+<span id="anchor-59"></span>
+
+<span id="anchor-60"></span>
+
+<span id="anchor-61"></span>
+
+<span id="anchor-62"></span>September 30, 2020
+
+Attendees (Add your name and how you’re feeling today)
+
+  - Elizabeth Barron 🌼
+
+  - Matt Snell
+
+  - Ruth Ikegah- So tired :(
+
+  - Laura Dabbish - post debate recovery 🙇🏻‍♀️
+    
+      - > Me too\!
+
+  - Xiaoya - Back home\!
+
+  - Anita Ihuman😅bug filled day 
+
+  - Tola - got in late today 
+
+  - Georg Link - excited for Friday
+
+  - Nicole Huesman -- between meetings, but so glad to be here\!
+
+  - J.W.F. – sorry to be late\! But happy to listen in to today’s
+    conversation.
+
+Video: [*https://youtu.be/cjF66DwQCSs*](https://youtu.be/cjF66DwQCSs) 
+
+Notes:
+
+  - Badging:
+    
+      - > Outreach
+        
+          - Email Matt [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu)
+            to champion this effort
+    
+      - > One event from everyone? 
+        
+          -  Open Networking and Edge summit (LF)
+            
+              - > [*https://events.linuxfoundation.org/open-networking-edge-summit-north-america/program/program-committee/*](https://events.linuxfoundation.org/open-networking-edge-summit-north-america/program/program-committee/)
+        
+          -  [*All Things Open*](https://2020.allthingsopen.org/)
+            (October - might be too soon?) 
+            
+              - > Jennifer Suber
+                > [*jennifer@allthingsopen.org*](mailto:jennifer@allthingsopen.org)
+                > 
+        
+          -  KubeCon?
+            
+              - > [*events@cncf.io*](mailto:events@cncf.io) 
+        
+          -  [*FOSS Backstage*](https://foss-backstage.de/)
+            
+              - > [*https://foss-backstage.de/contact*](https://foss-backstage.de/contact)
+                > 
+        
+          - OpenStack Summit (October 2020)
+            
+              - > [*https://www.openstack.org/summit/*](https://www.openstack.org/summit/)
+                > 
+            
+              - > Could Amy M. help out here? 
+        
+          -  FOSDEM 2021
+            
+              - > [*info@fosdem.org*](mailto:info@fosdem.org) 
+        
+          - SCaLE (usually March)
+            
+              - > [*https://www.socallinuxexpo.org/*](https://www.socallinuxexpo.org/)
+                > 
+        
+          - Open Source Summit (LF)
+            
+              - > [*events@linuxfoundation.org*](mailto:events@linuxfoundation.org)
+                > 
+        
+          - Open Core Summit
+            
+              - > [*Info@OpenCoreSummit.com*](mailto:Info@OpenCoreSummit.com)
+                > 
+        
+          - SoHeal
+            
+              - > Bram Adams
+                > [*bram.adams@polymtl.ca*](mailto:bram.adams@polymtl.ca)
+                > 
+        
+          - CSCW 
+            
+              - > Jean Hardy: [*jhardy@msu.edu*](mailto:jhardy@msu.edu) 
+    
+      - > 
+
+  - Burnout
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit\#*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit#)
+
+<span id="anchor-63"></span>
+
+<span id="anchor-64"></span>September 23, 2020
+
+Attendees (Add your name and how you’re feeling today)
+
+  - Matt Germonprez - It is feeling like fall. Fog in the morning and
+    that’s a good thing
+  - Ruth Ikegah - Moderating today(pumped\!\!) 
+  - Vinod Ahuja - Its cloudy 
+  - Dawn Foster - it’s a rainy and dreary day here in the UK
+  - Elizabeth Barron - another beautiful day today
+  - Aastha - Just finished dinner :)
+  - Sean Goggins - Cool enough to have the windows open. Garage update:
+    waiting on steel
+  - Kevin Lumbard
+  -  Amy Marrich - Yep having breakfast:)
+  - Xiaoya - Rainy again 
+  - J.W.F – Early day today\! I began at 5am today. It is 11am now\!
+  - Georg - I’ve started to block more time on my calendar for “no
+    meetings”
+  - Stefka - happy to manage to join although late
+
+Video: [*https://youtu.be/-VM-R7HXi-Q*](https://youtu.be/-VM-R7HXi-Q) 
+
+Notes:
+
+  - D\&I Badging Program 
+
+[*https://chaoss.community/blog-post/2020/09/15/diversity-inclusion-badging-program/*](https://chaoss.community/blog-post/2020/09/15/diversity-inclusion-badging-program/)
+
+  - > Updates from Weekly Sync
+
+> [*https://docs.google.com/document/d/1PMDWc6xMe0fNE7shxTK5\_HE\_ykRBG5w55\_Zx5hvzsEY/edit\#*](https://docs.google.com/document/d/1PMDWc6xMe0fNE7shxTK5_HE_ykRBG5w55_Zx5hvzsEY/edit#)
+
+  - Xiaoya is working on the applying for badge section 
+    
+      - > [*https://app.gitbook.com/@chaoss-project/s/badging/applying-for-a-badge*](https://app.gitbook.com/@chaoss-project/s/badging/applying-for-a-badge) 
+        > 
+    
+      - > Perhaps include the very specific questions to the applicant
+        > and the reviewer from Family Friendliness 
+        
+          - We can perhaps start there 
+
+  - Burnout
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit\#*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit#)
+    
+      - > 
+
+  - Translation
+    
+      - > What documents? 
+        
+          - Translate the metrics releases 
+          - This would be in the associated GH pages 
+    
+      - > What languages? 
+        
+          - Chinese (Mandarin) 
+          - Spanish 
+    
+      - > We have funds to start the work and which ones would be the
+        > highest impact? 
+
+  - New metrics? 
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+
+<span id="anchor-65"></span>September 16, 2020
+
+Attendees (Add your name and how you’re feeling today)
+
+  -  Matt Snell - Eating an airline cheese snack plate
+  -  Eriol Fox - I think I need a new macbook mine is now struggling :(
+  - Elizabeth Barron - Chilly morning today\!
+  -  Laura Dabbish - fall vibes & good air quality today 🤗
+  -   Matt Germonprez -- Better week than last week\!\!\!
+  - Justin/JWF -- Is it possible to feel energized and tired at the same
+    time?
+  - Anita Ihuman -Really cold day and I am excited. 
+  - Georg Link - I look forward to painting this weekend.
+  - Kevin Lumbard
+  - Tola Ore-Aruwaji - did a lot of writing today
+  - Amy Marrich - yes it’s breakfast time
+  - Ruth Ikegah - Mood switches today
+  - Nicole Huesman - still super smoky here, so stuck inside
+
+Video:
+
+Notes:
+
+  - Facilitator next week?
+    
+      - > Ruth Ikegah 
+
+  - D\&I Badging launched yesterday 🎉
+    [*https://chaoss.community/blog-post/2020/09/15/diversity-inclusion-badging-program/*](https://chaoss.community/blog-post/2020/09/15/diversity-inclusion-badging-program/)
+    
+      - > 6 reviewers so far
+    
+      - > Reaching out to event organizers to participating in the
+        > initiative 
+        
+          - Q1 of 2021 may be a good target 
+    
+      - > Perhaps retroactive badging for events that were 6-12 months
+        > in the past?
+
+  - Grace Hopper Open Source Day October 1, join us if you’re
+    participating in the conference\!
+    [*https://ghc.anitab.org/programs-and-awards/open-source-day/2020*](https://ghc.anitab.org/programs-and-awards/open-source-day/2020)
+    
+      - > Augur and GrimoireLab 
+    
+      - > Openstack is participating as well 
+
+  - Burnout
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit\#*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit#)
+    
+      - > We have a lot of feedback to work on\!
+
+  - Justin’s D\&I OSD Summit
+    [*https://discourse.opensourcediversity.org/c/meta/summit/11*](https://discourse.opensourcediversity.org/c/meta/summit/11)
+    
+      - > New private category created on OSD forum for Summit
+        > logistics/organizing
+    
+      - > If you want read/post access, register an account on Open
+        > Source Diversity Discourse and let
+        > [*+jflory7@gmail.com*](mailto:+jflory7@gmail.com) know your
+        > username\!
+
+<!-- end list -->
+
+  - Translation \!\!
+    
+      - > Gitlocalize meeting today around workflow
+    
+      - > Tola is looking for help reviewing the translations that have
+        > been done so far
+    
+      - > Hugo documentation toolchain and translate
+
+<span id="anchor-66"></span>September 9, 2020 - canceled because of
+State of the Source Summit
+
+<span id="anchor-67"></span>September 2, 2020
+
+<span id="anchor-68"></span>Attendees
+
+Put your name and tell us how you are feeling:
+
+  - JWF – excited and nervous\! But y’all are great folks to talk with\!
+  - Ruth Ikegah - Attending two meetings at the same time.. phew\!
+  - Matt Snell - Baby cat is already driving me crazy
+  - Eriol Fox - Chocolate and coffee = friends
+  - Nikki Stevens - lots of work\!
+  - Matt Germonprez - Is it the weekend? 
+  - Amy Marrich - Breakfast is taking soo long this morning to cook:(
+  - Elizabeth Barron - It can’t decide if it’s gonna be sunny or rainy
+    today
+  - Anita ihuman - Network seems to want a piece of me ….. sobs
+  - Kevin Lumbard
+  - Aastha Bist - Sleepy but not enough to be able to sleep :/
+  - Georg Link - A little on edge, but mostly good
+  -  Nicole Huesman - Logging in from a vacation in Lake Chelan (eastern
+    Washington) with my 9 y/o son, and excited to take him on a
+    Waverunner for the first time later this morning\!
+
+<span id="anchor-69"></span>Video:
+[*https://youtu.be/1gaRJxde\_50*](https://youtu.be/1gaRJxde_50) 
+
+<span id="anchor-70"></span>Agenda
+
+  - Hellos / welcomes / introductions
+    
+      - > New folks are encouraged to introduce themselves\!
+
+  - Project burnout metrics
+    
+      - > Ruth/MattG
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit)
+        > 
+
+  - Open Demographics follow-up
+    
+      - > Any next steps / actions here?
+    
+      - > [*https://github.com/drnikki/open-demographics/issues/65*](https://github.com/drnikki/open-demographics/issues/65)
+    
+      - > Did the meeting happen already this week? Georg/MattG, any
+        > updates?
+        
+          - Updating OP without losing the original vision
+            
+              - > Keep it organization agnostic
+        
+          - Create issue to push conversation forward
+
+  - Badging
+    
+      - > Launch date: 14 September 2020
+    
+      - > Looking for reviewers :))))
+        
+          - Three calls next week to bring in new reviewers and
+            moderators and get everyone situated
+          - Please email
+            [*abist119@gmail.com*](mailto:abist119@gmail.com) or
+            [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu) to get
+            started or open an issue on
+            [*diversity-and-inclusion*](https://github.com/badging/diversity-and-inclusion)
+            repository
+
+  - Georg will be at State of the Source Summit next week: 
+    
+      - > Presentation: Metrics for open source in light of insights
+        > from the CHAOSS Project
+    
+      - > [*https://eventyay.com/e/8fa7fd14/schedule?date=2020-09-09*](https://eventyay.com/e/8fa7fd14/schedule?date=2020-09-09)
+    
+      - > Ruth is having a lightning talk session at State of the Source
+        > Summit (my first talk “*nervous*”)
+    
+      - > Presentation: A beginner-inclusive approach to open source
+
+  - Facilitator next week?
+    
+      - > 
+
+<span id="anchor-71"></span>Actions
+
+  - JWF: Open conversation on CHAOSS D\&I mailing list about how to talk
+    about burnout
+    
+      - > ML:
+        > [*https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion*](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion)
+        > 
+
+  - 
+
+  - 
+
+<span id="anchor-72"></span>August 26, 2020
+
+Attendees (Put your name and tell us how you are feeling): 
+
+  - JWF -- I was making my first pot of tea for today before this
+    meeting… but it was not ready in time for this meeting :O
+  - Georg Link - Tomorrow is my birthday 🤩
+  - Matt Germonprez - Happy birthday Eriol\!\!\!\!
+  - Vinod Ahuja - Happy birthday Eriol
+  - Armstrong Foundjem — Happy birthday Georg :) 
+  - Eriol Fox (they,them) Today is my birthday\!\!\! haha 
+  - Amy Marrich - HBD Eriol and not Georg to be culturally correct:)
+  - Aastha - Just finishing up with dinner :)
+  - Xiaoya - HBD Georg and Eriol \!\!
+  - Kevin Lumbard
+  - Silona Bonewald - Happy birthdays\!
+  - Elizabeth Barron - Happy birthday to Eriol and (early) to Georg\! 
+
+Video: [*https://youtu.be/MVqcfsaCNdk*](https://youtu.be/MVqcfsaCNdk) 
+
+Notes: 
+
+  - Open Demographics --
+    [*https://github.com/drnikki/open-demographics*](https://github.com/drnikki/open-demographics)
+    
+    
+      - > Reached out to Nikki and the response was positive --
+        > [*https://github.com/drnikki/open-demographics/issues/65*](https://github.com/drnikki/open-demographics/issues/65)
+        > 
+    
+      - > Meeting next week to discuss future maintenance of the Open
+        > Demographics
+    
+      - > The hope is to keep the work independent of a particular
+        > project or community or foundation and continue the Open
+        > Demographics work in the respective repository.
+
+  - D\&I Badging 
+    
+      - > Many updates but the release is coming soon :) 
+        
+          - **Need to recruit reviewers**
+            
+              - > 
+        
+          - Question: Where have you reached out to recruit reviewers?
+        
+          - Goal number of reviewers: 10+
+        
+          - We currently have reviewers: 3 or 4
+        
+          - Elizabeth and Matt S have been working on an email to invite
+            people.
+            
+              - > Share this also with the Open Source Diversity Group
+                > ([*https://discourse.opensourcediversity.org/*](https://discourse.opensourcediversity.org/))
+                > 
+    
+      - > Managing the notification flood for reviewers
+        
+          - JWF: Expectation-setting might help with this. I signed up
+            to volunteer but was overwhelmed by GitHub emails (even
+            though I loved the work -- it was just too much for me to
+            keep up with\!)
+          - Justin suggest un-watching the repository or the
+            organization and relying only on the tagged messages (bot
+            auto-tags reviewers when they need to take actions)
+    
+      - > Experience from Fedora project about Testing new releases
+        
+          - One day per week dedicated to “TEST DAY”
+        
+          - Well-documented and communicated expectations and tutorials
+        
+          - Outreach ahead of the day to get participants
+        
+          - On test day provide ample support to new contributors
+        
+          - Fedora examples:
+            
+              - > [*https://fedoramagazine.org/contribute-at-the-fedora-test-week-for-btrfs/*](https://fedoramagazine.org/contribute-at-the-fedora-test-week-for-btrfs/)
+            
+              - > [*https://fedoramagazine.org/contribute-at-the-fedora-kernel-and-gnome-test-days/*](https://fedoramagazine.org/contribute-at-the-fedora-kernel-and-gnome-test-days/)
+    
+      - > Updated template since reviews were shifted to be done in
+        > Issues
+        
+          - [*https://github.com/badging/event-diversity-and-inclusion/blob/master/.github/PULL\_REQUEST\_TEMPLATE.md*](https://github.com/badging/event-diversity-and-inclusion/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
+    
+      - > Badging (Launch Date: September 14, 2020\!)
+        
+          - Suggest the following (Matt G)
+            
+              - > Must hit all CoC items
+            
+              - > Must hit 2+ items in Family Friendly 
+            
+              - > Must hit 2+ items in Diversity Access Tickets
+            
+              - > For Speaker Demographics
+                
+                  - Remove the Review Team Demographics question as a
+                    reviewer 
+                  - Must attempt to capture and display the information 
+            
+              - > For Attendee Demographics 
+                
+                  - Must attempt to capture and display information 
+                    
+                      - > and/or 
+                
+                  - Must connect with attendees to determine if the
+                    event meet their diversity and inclusion
+                    expectations
+
+  - Project Burnout
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit)
+
+  - Facilitator next week: Justin Flory
+
+  - Amy shared that the Open Stack Foundation is removing diverse
+    language from all its projects
+    
+      - > Currently collecting resources:
+        
+          - [*https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language
+            this is RH
+            stance *](https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language)
+          - 
+    
+      - > We will continue discussing it in the future more
+    
+      - > Amy will share links and resources on the CHAOSS D\&I WG
+        > mailing list:
+        
+          - [*https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion*](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-diversity-inclusion)
+    
+      - > 
+
+<span id="anchor-73"></span>
+
+<span id="anchor-74"></span>August 19, 2020
+
+Attendees (Put your name and tell us how you are feeling): 
+
+  -  
+  -  Matt Germonprez - Excited about the Badging Program
+  -  Matt Snell - Happy to be here :)
+  -  Elizabeth Barron - It’s a lovely day today\! 
+  -  Georg Link - Trying to buy land … fun times. \[Sounds exciting,
+    Georg\! \~ Nicole\]
+  -  Xiaoya - Thanks\!
+  - Silona Bonewald - Dandy\!
+  - Armstrong Foundjem - 
+  - Aastha - sitting beside a stack of notebooks
+  - Kevin Lumbard
+  - JWF - tired/sleepy but excited for this topic\!
+  - Ruth Ikegah - Procrastinations are ruining my day
+  - Nicole Huesman - Bright, sunny day & happy to be here\!
+
+Video: [*https://youtu.be/viNWMTOjMe8*](https://youtu.be/viNWMTOjMe8) 
+
+Notes: 
+
+  - Facilitator next week: Georg Link
+
+  - Congratulations to Xiaoya - Google Season of Docs\!
+    
+      - > Community bonding period for about a month
+
+  - Open Demographics
+    \<**[*https://github.com/drnikki/open-demographics*](https://github.com/drnikki/open-demographics)\>
+    
+      - > AI Matt: Open an issue with an intent to fork 
+        
+          - Link to:
+            [*https://github.com/drnikki/open-demographics/issues/64*](https://github.com/drnikki/open-demographics/issues/64)
+          - Create a Fork 
+          - Ping Silona to reach out to her on Twitter 
+    
+      - > Naming: Demographic Questions 
+    
+      - > Creating a CHAOSS repo for this purpose (not a fork I agree)
+        > and slowly porting over 
+        
+          - Mozilla standards
+          - Those in OD repo that feel complete, or validated in
+            associated discussions
+    
+      - > Credits the original work
+    
+      - > Focusing on a few at a time, the maintenance of that repo
+        > (which will likely be responding to a lot of comments)
+
+  - Burnout Metrics
+    
+      - > [*https://docs.google.com/document/d/1XYvlo8uzaQ\_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit?ts=5f3428b1\#heading=h.8r28m5czyl5q*](https://docs.google.com/document/d/1XYvlo8uzaQ_YEUHyTHC92CZrQORQRBRLyZmaHaQlRzU/edit?ts=5f3428b1#heading=h.8r28m5czyl5q)
+
+  - D\&I Issues (Three per week\!)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+
+  - Forum
+    
+      - > AI Elizabeth: 
+
+  - D\&I
+    
+      - > Send out a tweet to get the word out that the badging process
+        > is coming, that would be great. 
+        
+          - This could be in early september and it may also help in
+            recruiting reviewers
+
+<span id="anchor-75"></span>August 12, 2020
+
+Attendees (Put your name and tell us how you are feeling): 
+
+  - [*JWF*](https://jwf.io) – feeling calm and relaxed - a pretty day
+    after a week of intense rain\!
+  - Matt Germonprez - Thinking about the semester now. Not sure where
+    the time will come from :) 
+  - Ruth Ikegah - Feeling tired\!
+  - Dawn Foster - we’re having a rare thunderstorm here in the UK\!
+  - Eriol fox - It’s very warm here so too hot. (33 degrees)
+  - Georg Link - First time in weeks that I don’t feel stressed about
+    stuff.
+  - Matt Snell - Happy to be here :)
+  - Kevin Lumbard
+  - Tola Ore-Aruwaji - finally made it here 
+  - Saleh Abdel Motaal — Happy to (almost) be here :)
+  - Aastha - not sure how I feel
+
+Video: [*https://youtu.be/D0s1Xryc\_r8*](https://youtu.be/D0s1Xryc_r8) 
+
+Notes: 
+
+  - Facilitator next week: Matt Snell
+
+  - D\&I Issues
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+        > 
+    
+      - > Open Demographics
+        
+          - AI Matt G: Reach out to Emma regarding ODG
+            
+              - > Done
+
+  - Documentation Metrics
+    
+      - > Released
+        
+          - [*https://chaoss.community/metric-documentation-usability/*](https://chaoss.community/metric-documentation-usability/)
+    
+      - > For next release 
+        
+          - Documentation Discoverability:
+            
+              - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - Documentation Accessibility
+            
+              - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+  - Burnout
+    
+      - > New Metric Candidate
+    
+      - > Considering how people are burned out on a project
+    
+      - > Seeing people draw away from project activities
+    
+      - > Helping manage burnout 
+    
+      - > Things that might be leading indicators for burnout 
+    
+      - > Are there questions that are made available to identify if
+        > people are in burnout? 
+    
+      - > Burnout that is not only technical -- could be other
+        > community-related activities and these activities may simply
+        > not be measurable or being measured
+        
+          - *JWF*: I think burnout could be measured, because there is
+            often invisible work to a community that is poorly
+            understood.
+          - *JWF*: I think people who burn out are often doing more work
+            than people might realize (not always true, but I think
+            often)
+    
+      - > *Eriol*: but I think some metrics ideas re. Burnout might be:
+        > How often a project talks about burnout, has burnout check
+        > ins, has docs.
+        
+          - I know it sounds icky, but I would actually be really
+            interested in a number of people that have indicated burnout
+    
+      - > GL: Just a thought, projects could ask members (maintainers?)
+        > take a burnout assessment survey and anonymously summarize the
+        > results.
+    
+      - > AI: Matt G and Ruth will work to build the framework for a
+        > metric on Burnout 
+        
+          - Done
+
+  - D\&I Badging
+    
+      - > Issues vs. PRs
+    
+      - > Web form - demo
+    
+      - > Second Pilot testing next week - August 17 to August 21
+    
+      - > *JWF*: Question about participation expectations
+        > (low-priority)
+    
+      - > Percentage based badge assignment demo -
+        > [*https://github.com/bistaastha/bot-showcase/pull/7\#issuecomment-671053695*](https://github.com/bistaastha/bot-showcase/pull/7#issuecomment-671053695)
+
+  - D\&I of the CHAOSS project
+    
+      - > Appx. 5 advisors to review the CHAOSS project
+
+<span id="anchor-76"></span>August 5, 2020
+
+Attendees (Put your name and tell us how you are feeling): 
+
+  - Matt Germonprez 
+  - Laura Dabbish 
+  - Elizabeth Barron - still blueberryish
+  - Tharun
+  - Justin W. Flory - taking this call outside to change up office space
+    :) 
+  - Matt Snell - Got a haircut\! (Feeling free)
+  - Amy Marrich - breakfast\!:)
+  - Eriol fox - hungry/snacky
+  - Saleh Abdel Motaal — I was planning to be here (kinda here)
+  - Tola Ore-Aruwaji 
+  - Nicole Huesman -- spending time with the family this week\!
+
+Video: [*https://youtu.be/9kFazA6-HKU*](https://youtu.be/9kFazA6-HKU) 
+
+Notes: 
+
+  - Facilitator next week: Matt G (Matt S is doing a demo)
+
+  - Release Metric Candidates
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    
+      - > [***Inclusive
+        > Leadership***](https://github.com/chaoss/wg-diversity-inclusion/issues/292)
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/292*](https://github.com/chaoss/wg-diversity-inclusion/issues/292)
+            
+    
+      - > **Issue Label Inclusivity:** We didn’t get to this metric last
+        > week, need to respond to feedback\!
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/291*](https://github.com/chaoss/wg-diversity-inclusion/issues/291)
+    
+      - > **Documentation Usability**
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/288*](https://github.com/chaoss/wg-diversity-inclusion/issues/288)
+            
+          - AI Matt S: Issue a pull request with Laura’s & Ray’s Changes
+          - Suggestion from Eriol - consider time diversity /
+            differences in availability parental time constraints -
+            possible mod under structural constraints - make
+            documentation navigable, consumable in short time bursts
+    
+      - > Suggestion: Post changelog of new metrics on Open Source
+        > Diversity community forum - draw from release notes (Matt G.
+        > will do this when the release is officially done) 
+
+  - Global D\&I Summit 
+    
+      - > Virtual summit towards the end of 2020 / early 2021
+        > **(Free\!)**
+    
+      - > [*https://discourse.opensourcediversity.org/t/call-for-interest-global-open-source-diversity-summit/359/10*](https://discourse.opensourcediversity.org/t/call-for-interest-global-open-source-diversity-summit/359/10)
+        > 
+    
+      - > 2 Calls for this:
+        
+          - Call 1: Friday, 14 August 2020, 18:00-19:00 UTC
+          - Call 2: Friday, 21 August 2020, 17:00-18:00 UTC
+
+  - D\&I Badging Program 
+    
+      - > This week is bot week\!
+    
+      - > Second pilot test begins on the 17th (contact
+        > [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu) :)
+    
+      - > Also mentioning the idea of CHAOSS programs 
+
+  - OpenInfra Summit - CFP closed but D\&I topics submitted plus
+    hopefully B0F and WG sessions
+    
+      - > [*https://www.openstack.org/summit/2020/*](https://www.openstack.org/summit/2020/)
+        > 
+
+  - (deferred until next week) D\&I within the CHAOSS project
+
+> 
+
+<span id="anchor-77"></span>July 29, 2020
+
+Attendees: 
+
+  - Elizabeth Barron - Got shampoo in my eyes this morning 
+  - Amy Marrich - sorry for all the conflicts at this time lately
+  - Magali Ngouabou
+  - Tola Ore-Aruwaji - Excited to be here :)
+  - Silona Bonewald - recovering from being a bit sick
+  - Matt S - Will be a little late\!
+  - Aastha - Slowly processing everything
+  - Georg Link 
+  - Saleh Abdel Motaal — Remembered to mention the agenda item :)
+  - Sean Goggins
+  - Laura Dabbish
+
+Video: [*https://youtu.be/9c5uSli5jU0*](https://youtu.be/9c5uSli5jU0) 
+
+Notes: 
+
+  - Facilitator next week: Laura Dabbish (THANK YOU\!\!)
+  - Survey (get involved\!)
+
+[***mnoubiss@andrew.cmu.edu***](mailto:mnoubiss@andrew.cmu.edu)** -
+Magali Ngouabou**
+
+My name is Magali Ngouabou and I am part of a research team at Carnegie
+Mellon University seeking to learn more about familiarity and
+accessibility of open source to Black and other underrepresented
+individuals to enhance access to employment opportunities through open
+source. Can you help us send this survey to the people in your
+organization, inviting them to participate in our study? That includes
+alums, current participants, program organizers, or anyone else who you
+think would be relevant to the study.
+
+Survey link:[
+](http://cmu.ca1.qualtrics.com/jfe/form/SV_6Wk8vBXFfeuxjX7)[*http://cmu.ca1.qualtrics.com/jfe/form/SV\_6Wk8vBXFfeuxjX7*](http://cmu.ca1.qualtrics.com/jfe/form/SV_6Wk8vBXFfeuxjX7)
+
+Open source refers to the method of creating software in collaborative
+spaces such as GitHub, GitLab, etc. Surveys suggest minority
+representation in open source is low, but there is virtually no
+information on the Black experience in these spaces.
+
+These past few months have been especially difficult on the Black
+community, and we fully acknowledge that this research is coming at a
+time where the population for this survey is under even more pain and
+stress than usual. In light of this, we truly appreciate your support in
+connecting with your organization’s members as any insight from the
+community would be helpful.
+
+  - Resources:
+    
+      - > Lists.openstack.org - join the openstack discuss and
+        > foundation lists to send
+    
+      - > List of old surveys with links to items:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/220\#issuecomment-625467897*](https://github.com/chaoss/wg-diversity-inclusion/issues/220#issuecomment-625467897)
+    
+      - > Red Hat - email either
+        > [*amy@demarco.com*](mailto:amy@demarco.com) or
+        > [*amy@redhat.com*](mailto:amy@redhat.com) and I’ll share
+        > internally
+    
+      - > GitHub - email [*toyae@github.com*](mailto:toyae@github.com)
+        > (she’s in the Social Impact team there, and can connect you
+        > with the Blacktocats (tell her Elizabeth says HIIII :) )
+    
+      - > Black Girls Code, Code2040, Blacks in Tech -- if you need
+        > contacts there email me (elizabeth@naramore.net)
+    
+      - > [*https://opensourcediversity.org/*](https://opensourcediversity.org/)
+        > -- share your work on the forum there as well -- very
+        > supportive people who will also spread the word.
+    
+      - > Node.js issue to include the first question related to
+        > accessibility —
+        > [*https://github.com/nodejs/community-committee/issues/538*](https://github.com/nodejs/community-committee/issues/538)  
+        > Please connect with me, Saleh
+        > \<[*saleh@smotaal.io*](mailto:saleh@smotaal.io)\> once we are
+        > ready to do a pilot run (hopefully I could help get it
+        > incorporated in Node.js’s next survey).
+
+  - Just wanted to say OpenInfra Summit CFP is open and there’s an Open
+    Development track which would include D\&I -
+    [*https://cfp.openstack.org*](https://cfp.openstack.org) (virtual
+    only - Dates are October 19-23)
+    
+      - > CfP Open until Tuesday night 
+    
+      - > [*https://www.openstack.org/summit*](https://www.openstack.org/summit)
+
+  - D\&I Badging call to action
+    
+      - > Need reviewers, moderators and applicants
+        
+          - Contact [*msnell@unomaha.edu*](mailto:msnell@unomaha.edu) or
+            [*abist119@gmail.com*](mailto:abist119@gmail.com) (Or both
+            of us\!)
+          - Learn more:
+            [*https://github.com/badging/diversity-and-inclusion*](https://github.com/badging/diversity-and-inclusion)
+    
+      - > 2nd Pilot testing starts at the middle of August (Aug 17-21)
+
+  - Release Metric Candidates
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    
+      - > **Inclusive Leadership**: no comments to be resolved
+    
+      - > **Documentation Usability**: We had some comments and needed
+        > to ask for clarification for others
+    
+      - > **Issue Label Inclusivity:** We didn’t get to this metric
+        > today
+
+<span id="anchor-78"></span>July 22, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonrpez - Birthday tomorrow\! 
+  -  Tola Ore-Aruwaji - Feeling great.  
+    Happy birthday in advance Matt G
+  -  Elizabeth Barron - happy early birthday Matt G\!
+  -  Matt Snell - I’m happy :)
+  -  Tharun Ravuri - Working hard (BTW Advance HBD Matt 🥳)
+  -  Aastha - Kind of sleepy
+  - Saleh Abdel Motaal — Happy 🎂day Matt
+
+Video: [*https://youtu.be/yHqlSwplzyY*](https://youtu.be/yHqlSwplzyY) 
+
+**Agenda / Notes**:
+
+  - Facilitator for next week: Elizabeth 
+
+  - Badging Update
+    
+      - > How did the pilot testing go? 
+        
+          - Learned a lot about the process
+        
+          - Qualitative and quantitative was reworked
+        
+          - Working on a new badge level system 
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/299*](https://github.com/chaoss/wg-diversity-inclusion/issues/299)
+            
+              - > This includes new possible new metrics for the D\&I WG
+        
+          - Badging Criteria idea
+            
+              - > [*https://gist.github.com/bistaastha/fe185b05d98415766789fb837df821d2*](https://gist.github.com/bistaastha/fe185b05d98415766789fb837df821d2)
+        
+          - Place link to PR in badge SVG to capture the requirements in
+            place at the time and the discussion
+        
+          - The hope is to still have a functional process by the end of
+            August 
+
+  - Metrics Release 
+    
+      - > [*https://chaoss.community/metrics/\#user-content-focus-area---event-diversity*](https://chaoss.community/metrics/#user-content-focus-area---event-diversity)
+
+  - CHAOSS D\&I Reflection
+    
+      - > Ford Foundation
+        
+          - Design Guidelines 
+        
+          - Minimum viable design documentation. Example: [*Contributing
+            to Pa11y*](https://pa11y.org/contributing/)
+        
+          - [*New idea: Interview campaign with underrepresented groups
+            in Open Source -
+            chaoss/wg-diversity-inclusion\#294*](https://github.com/chaoss/wg-diversity-inclusion/issues/294)
+            
+              - > On-boarding conversation with regards to Design?
+            
+              - > Including UX designers
+            
+              - > Incorporating design into the metrics
+        
+          - Related? 
+
+<span id="anchor-79"></span>
+
+<span id="anchor-80"></span>July 15, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - 
+  - Matt S - Chilling with a nice rainy day :)
+  - Dawn Foster - non-stop meeting marathon day\! 🤪
+  - Tharun Ravuri - Feeling Neutral
+  - Aastha - I am sitting beside a bunch of notebooks
+  - Justin (JWF) - Sipping warm tea on this rainy, quiet day\!
+  - Matt Germonprez - I have a calculator watch
+  - Eriol Fox - I’m wiped out ---Aastha: Hi\!
+  - 
+  - Elizabeth Barron - juggling lots of balls in the air today\!
+  - Xiaoya - So excited about the upcoming review process\!
+  - Ruth Ikegah- Gloomy day but having some cake
+  - Samson Goddy - Doing okay
+  - Nicole Huesman - really enjoying this morning’s discussion
+  - Georg Link - joining late
+
+Video: [*https://youtu.be/WxMdLWbbBw8*](https://youtu.be/WxMdLWbbBw8) 
+
+**Agenda / Notes**:
+
+  - Badging Application Demo
+
+  - Badging Review Demo (If time permits)
+
+  - [*New idea: Interview campaign with underrepresented groups in Open
+    Source -
+    chaoss/wg-diversity-inclusion\#294*](https://github.com/chaoss/wg-diversity-inclusion/issues/294)
+    
+      - > On-boarding conversation with regards to Design?
+    
+      - > Including UX designers
+    
+      - > Incorporating design into the metrics
+
+  - Quora as a platform
+    
+      - > Consensus?
+    
+      - > Positive interest in this call
+
+  - Minimum viable design documentation. Example: [*Contributing to
+    Pa11y*](https://pa11y.org/contributing/)
+
+  - Possibly include a metric around how designers can contribute 
+
+<span id="anchor-81"></span>July 8, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Georg Link, we are celebrating a birthday in the family today :)
+  - Elizabeth Barron - Hot today in Ohio
+  - Tharun Ravuri - Feeling tired :(
+  - Aastha - Ate mangoes after dinner a few minutes ago :)
+  - Matt Snell - Still excited about bearded dragon
+  - Matt Germonprez - Hoping the next semester goes as planned
+  - Stefka Dimitrova - feeling sorry that I can only join late for this
+    meeting
+  - Tola Ore-Aruwaji - Came in Late today, :(
+
+Video: [*https://youtu.be/RT2PauWD7kk*](https://youtu.be/RT2PauWD7kk) 
+
+**Agenda / Notes**:
+
+  - Facilitator today: Elizabeth
+
+  - Facilitator next week?
+    
+      - > Matt Snell
+
+  - D\&I Badging
+    
+      - > Badging Release Cycle
+        
+          - Just get things on GH :) 
+    
+      - > Badge Validity
+        
+          - 1 year
+        
+          - Context of each review
+            
+              - > Add disclaimer (This will be tougher)
+        
+          - Adding to the list - Front facing
+            
+              - > Always append to image 
+    
+      - > **Pilot testing reschedule to next week Monday to Friday**
+    
+      - > Conformance Documents
+        
+          - Terms & Conditions and Conformance for submitters
+        
+          - Update documents and finalize changes with Steve W
+            
+              - > [*https://docs.google.com/document/d/1qVV8za7FNVq9fVJ99BCobDYhVM2VxRqUIl-QgroLjRk/edit*](https://docs.google.com/document/d/1qVV8za7FNVq9fVJ99BCobDYhVM2VxRqUIl-QgroLjRk/edit)
+            
+              - > [*https://docs.google.com/document/d/1\_pH1WW6w7SzrVp9mm3dfKUmFLeO8EKqLmhZXr0MiNFc/edit*](https://docs.google.com/document/d/1_pH1WW6w7SzrVp9mm3dfKUmFLeO8EKqLmhZXr0MiNFc/edit#heading=h.gjdgxs)
+    
+      - > Process
+        
+          - Initial Application
+          - Renewal
+          - Information Management
+
+  - Release update -- address feedback?
+
+<span id="anchor-82"></span>July 1, 2020 -- Canceled
+
+Many CHAOSS members will be attending the Open Source Summit North
+America:[
+](https://events.linuxfoundation.org/open-source-summit-north-america/)[*https://events.linuxfoundation.org/open-source-summit-north-america/*](https://events.linuxfoundation.org/open-source-summit-north-america/)
+
+**Join these CHAOSS related sessions:**
+
+> Monday, June 29 
+
+> 12:20pm (UTC -5)
+
+> [*C in CRM Stands for Community: The DevRel Way - Ana Jimenez
+> Santamaria,
+> Bitergia*](https://ossna2020.sched.com/event/c3ZH/c-in-crm-stands-for-community-the-devrel-way-ana-jimenez-santamaria-bitergia)
+> 
+
+> Monday, June 29 
+
+> 12:55pm (*UTC -5*)
+
+> [*Growing Participation in Your Company’s OSS Projects - Dawn Foster,
+> VMware*](https://ossna2020.sched.com/event/c3Sq/growing-participation-in-your-companys-oss-projects-dawn-foster-vmware)
+
+> Monday, June 29 
+
+> 2:05pm (*UTC -5*)
+
+> [*Diversity & Inclusion Badging Program - Matt Germonprez & Matt
+> Snell, University of Nebraska at
+> Omaha*](https://ossna2020.sched.com/event/c46X/diversity-inclusion-badging-program-matt-germonprez-matt-snell-university-of-nebraska-at-omaha)
+
+> Monday, June 29
+
+> 3:20pm (UTC -5)
+
+> [*Ensuring That Documentation Is a First-class Citizen in Open Source
+> Projects - Ray Paik, GitLab & Sofia Wallin, Ericsson Software
+> Technology*](https://ossna2020.sched.com/event/c3SY/ensuring-that-documentation-is-a-first-class-citizen-in-open-source-projects-ray-paik-gitlab-sofia-wallin-ericsson-software-technology)
+> 
+
+> Monday, June 29 
+
+> 4:20pm (UTC -5)
+
+> [*BoF: Discussing Metrics for Open Source in Light of Insights From
+> the CHAOSS Project - Georg Link,
+> Bitergia*](https://ossna2020.sched.com/event/c3T5/bof-discussing-metrics-for-open-source-in-light-of-insights-from-the-chaoss-project-georg-link-bitergia)[*
+> BoF: The CHAOSS Project: Answering Specialized Questions About
+> Community Health and Sustainability at Scale - Sean P. Goggins,
+> University of
+> Missouri*](https://ossna2020.sched.com/event/c3Xy/bof-the-chaoss-project-answering-specialized-questions-about-community-health-and-sustainability-at-scale-sean-p-goggins-university-of-missouri)
+
+> Tuesday, June 30
+
+> 2:00pm (UTC -5)
+
+> [*Panel: Succession Planning for the Open Source Movement - Georg
+> Link, Bitergia; Dawn Foster, VMware; Michael Downey, Digital Impact
+> Alliance (DIAL) at the United Nations Foundation & Maria Cruz,
+> Google*](https://ossna2020.sched.com/event/c3WK/panel-succession-planning-for-the-open-source-movement-georg-link-bitergia-dawn-foster-vmware-michael-downey-digital-impact-alliance-dial-at-the-united-nations-foundation-maria-cruz-google)
+
+> Wednesday, July 1
+
+> 1:50pm (UTC -5)
+
+> [*Tell Me Right Away\! Machine Learning for Push Notification of
+> Community Blips, Fires, and Victories - Sean Goggins & Gabe Heim,
+> University of
+> Missouri*](https://ossna2020.sched.com/event/c3YA/tell-me-right-away-machine-learning-for-push-notification-of-community-blips-fires-and-victories-sean-goggins-gabe-heim-university-of-missouri)
+
+<span id="anchor-83"></span>June 24, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Dawn Foster - feeling warm - it’s a hot one here in the UK today\! 🔥
+  - Elizabeth Barron - it’s a gorgeous day and the birds are singing :) 
+  - Tharun Ravuri - Feeling sleepy -\_-
+  - Matt Germonprez -- Garden is doing well. A few plants aren’t doing
+    so well and I don’t really know why. 
+  - Tola Ore-Aruwaji - a lot of work today :(
+  - Aastha Bist - happy for no particular reason :)
+  - Alberto -- running late\! :P Glad to be participating at my first
+    meeting\!
+  - Justin W. Flory -- Excited with this work and my open source work\!
+  - Georg Link -- happy that it’s Wednesday
+  - Xiaoya -- tired but excited
+  - Amy Marrich - hungry:) - My zucchini plants got eaten by something
+  - Nicole Huesman -- it’s a gorgeous morning in the Pacific Northwest,
+    and Duncan & I staked our tomatoes yesterday afternoon\!
+  - Armstrong Foundjem 
+
+Video: 
+
+**Agenda / Notes**:
+
+  - Facilitator today: Matt Snell
+    
+      - > Matt S needs a backup for today
+
+  - Facilitator next week?
+    
+      - > Elizabeth 
+
+  - Metric Release
+    
+      - > Review period starts. Are we ready? We’ll need to review the
+        > issues for the next 4 weeks and resolve comments.
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/292*](https://github.com/chaoss/wg-diversity-inclusion/issues/292)
+        
+          - Inclusive Leadership
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/291*](https://github.com/chaoss/wg-diversity-inclusion/issues/291)
+        
+          - Issue Label Inclusivity
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/288*](https://github.com/chaoss/wg-diversity-inclusion/issues/288)
+        
+          - Documentation Usability
+
+  - GSoC / Outreachy Update
+    
+      - > Building the workflow 
+    
+      - > Looking for volunteers to help pilot things 
+        
+          - Matt
+          - Elizabeth 
+          - Tharun
+          - Xiaoya
+          - [*Justin*](mailto:jflory@unicef.org)
+    
+      - > Closed Captioning at Virtual (or in-person) Event 
+        
+          - New Potential Metric\! 
+    
+      - > Translation -- Tola 
+        
+          - Moving from Weblate to Locilze for translation 
+        
+          - [*https://gist.github.com/thecraftman/1fc780edc5cad18469b823880595f95e*](https://gist.github.com/thecraftman/1fc780edc5cad18469b823880595f95e)
+            
+        
+          - Considering how to integrate the translation process into GH
+        
+          - Translating existing documents -- as automated into GH
+            actions 
+        
+          - Need to think about how we a guarantee the translation 
+            
+              - > Likely need to rely on people to check 
+
+  - Ethics Statement
+    
+      - > Make a CHAOSS statement about privacy and ethics around
+        > metrics and analytics
+        
+          - We can make a disclaimer in our metrics release:
+            
+              - > The CHAOSS project recognizes that there are ethical
+                > and legal challenges when using the metrics and
+                > software provided by the CHAOSS community. The
+                > particular challenges arise in the use that is
+                > specific to your context. 
+                
+                  - Ethical challenges exist around protecting community
+                    members and empowering them with their personal
+                    information.
+                  - Legal challenges exist around GDPR and similar laws
+                    or regulations that protect personal information of
+                    community members. 
+    
+      - > **AI Georg:** Open issue in the chaoss/website repo to include
+        > it in the release candidate.
+
+<span id="anchor-84"></span>June 17, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez - My runs are too hot (temperature-wise)
+  - [*Justin W. Flory*](https://jwf.io/); feeling excited to learn
+  - Amy Marrich - still making breakfast:)
+  - Elizabeth Barron - feeling ok\!
+  - Matt Snell - Having a great day\! Hope you are too\!
+  - Tola Ore-Aruwaji - Having a good time :)
+  - Georg Link - Enjoying the summer
+  - Saleh Abdel Motaal — I’m not even sure :)
+  - Aastha Bist - Feeling a little sleepy
+  - Xiaoya - so many works to be done :(
+
+Video: [*https://youtu.be/Zq5rQ2hmOL0*](https://youtu.be/Zq5rQ2hmOL0) 
+
+**Agenda / Notes**:
+
+  - Facilitator next week?
+    
+      - > Matt Snell
+
+  - Review action items:
+    
+      - > **AI: Matt and Elizabeth** -- Label all Metrics Ideas as
+        > Metrics Ideas and close issues that are older than 2 months
+        > with no activity. ALSO, include the closed issue in the
+        > tracking spreadsheet. 
+        
+          - Issues are tagged and closed
+          - **AI**: Add metrics to the tracking spreadsheet.
+    
+      - > **AI: Georg** -- Write in the README.md about our way of
+        > managing metric ideas. Link to the issue label “metric idea”
+        > of open and closed issues. Explain that issues are closed if
+        > not actively being moved forward.
+        
+          - no update
+    
+      - > **AI: Mariam** -- PR and issue for releasing the Issue Label
+        > Inclusivity metric
+        
+          - Metric:
+            [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/issue-label-inclusivity.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/issue-label-inclusivity.md)
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/291*](https://github.com/chaoss/wg-diversity-inclusion/issues/291)
+    
+      - > **AI: Georg** -- PR and issue for releasing the Documentation
+        > Usability metric
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/documentation-usability.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/documentation-usability.md)
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/292
+            *](https://github.com/chaoss/wg-diversity-inclusion/issues/292)
+    
+      - > **AI Matt Snell: ** Convert the items in the [*Inclusive
+        > Leadership
+        > metric*](https://docs.google.com/document/d/1_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing)
+        > into questions.
+        
+          - Done\!
+          - [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/leadership/inclusive-leadership.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/leadership/inclusive-leadership.md)
+          - [*https://github.com/chaoss/wg-diversity-inclusion/issues/292*](https://github.com/chaoss/wg-diversity-inclusion/issues/292)
+
+  - Metric Release
+    
+      - > Issue Label Inclusivity
+    
+      - > Inclusive Leadership
+    
+      - > Documentation Usability
+    
+      - > These are all ready to go for the release :)
+
+  - Metric Release Spreadsheet License
+    
+      - > Proposed: Release under Creative Commons license
+        
+          - Proper attribution, while it is easier to edit and reuse the
+            document
+    
+      - > Will continue the conversation on the mailing list
+
+  - Discuss Open Demographics
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/286*](https://github.com/chaoss/wg-diversity-inclusion/issues/286)
+    
+      - > It is critical to have these kinds of questions maintained
+        > because they are central to understanding D\&I in open source
+    
+      - > If no one else maintains them, then we may have to 
+    
+      - > A big challenge we may be able to help others with is
+        > recommendations on how to ethically and legally collect,
+        > manage, and analyze this data.+1
+    
+      - > **AI Georg:** Reach out to Nikki Stevens, creator and
+        > maintainer of the Open Demographics
+    
+      - > Follow up in future meetings
+
+  - Aastha -
+    
+      - > Project checklist as a PR comment -
+        > [*https://github.com/bistaastha/project-diversity-and-inclusion/pull/2*](https://github.com/bistaastha/project-diversity-and-inclusion/pull/2)
+    
+      - > Project checklist as a Gist -
+        > [*https://github.com/bistaastha/project-diversity-and-inclusion/pull/1*](https://github.com/bistaastha/project-diversity-and-inclusion/pull/1)
+
+  - GSoC / Outreachy Update
+
+  - Ethics Statement
+    
+      - > Make a CHAOSS statement about privacy and ethics around
+        > metrics and analytics
+        
+          - We can make a disclaimer in our metrics release:
+            
+              - > The CHAOSS project recognizes that there are ethical
+                > and legal challenges when using the metrics and
+                > software provided by the community. The specific
+                > challenges arise in the use that is specific to your
+                > context. 
+                
+                  - Ethical challenges are around protecting our
+                    community members and empowering them with their
+                    personal information.
+                  - Legal challenges are around GDPR and similar laws
+                    that protect personal information of our community
+                    members. 
+
+<span id="anchor-85"></span>June 10, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez - Cooler weather means more gardening
+  - Tharun Ravuri - Happy to be a part of CHAOSS community
+  - Xiaoya Xia - I have milk tea today
+  - Matt Snell - Happy to be here
+  - Elizabeth Barron - Happy to meet everyone\!
+  - Mariam Guizani - Having a good day :)) 
+  - Georg Link - Enjoying a nice day after a big storm.
+  - Tola Ore-Aruwaji - Excited to be here
+  - Saleh Abdel Motaal — Only 1 minute late today, happy to see so many
+    here :)
+  - Aastha Bist - Finally here\!
+
+Video: [*https://youtu.be/xnAthK9bqho*](https://youtu.be/xnAthK9bqho) 
+
+**Agenda/Notes**:
+
+  - Facilitator next week?
+    
+      - > Georg Link
+
+  - Open Issues and PRs
+    
+      - > Maybe look at 10?
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/*](https://github.com/chaoss/wg-diversity-inclusion/issues/)
+    
+      - > **AI: Matt and Elizabeth** -- Label all Metrics Ideas as
+        > Metrics Ideas and close issues that are older than 2 months
+        > with no activity. ALSO, include the closed issue in the
+        > tracking spreadsheet. 
+    
+      - > **AI: Georg** -- Write in the README.md about our way of
+        > managing metric ideas. Link to the issue label “metric idea”
+        > of open and closed issues. Explain that issues are closed if
+        > not actively being moved forward.
+    
+      - > **Idea: Tharun** (chat) — I think if we label and close the
+        > issues older than 2 months then only 5-6 issues will remain.
+        > But instead of that why don't we involve the issues as
+        > microtasks for GSoD participants. Just a thought :)
+
+> 
+
+  - Issue Inclusivity 
+    
+      - > [*https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit\#*](https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit#)
+        
+          - Let’s finish this up
+          - Create PR and Issue now
+          - **AI: Mariam** is going to do this\!\!
+
+  - Documentation Usability 
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - Let’s finish this up
+          - Create PR and Issue now
+          - **AI Georg:** Create a PR --done
+
+  - Discuss Open Demographics
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/286*](https://github.com/chaoss/wg-diversity-inclusion/issues/286)
+    
+      - > Talk about next week. 
+
+  - Metric release
+
+  - Matt Snell presented on the D\&I Badging Program
+    
+      - > Presentation at OSSNA on June 29, 2020 at 2:05PM
+    
+      - > [*https://sched.co/c46X*](https://sched.co/c46X)
+
+  - Open Source Day at the Grace Hopper Celebration
+
+**Benefits **  
+
+1.  Expose your project to a large community of women in technology. 
+
+<!-- end list -->
+
+2.  Receive 2 tickets to attend the virtual Grace Hopper Celebration
+    held September 29, 2020 through October 2, 2020. 
+
+<!-- end list -->
+
+3.  Build a community of diverse contributors. 
+
+**Expectations**  
+
+1.  Each project should provide:  
+
+<!-- end list -->
+
+1.  Well-defined issues for contributors to work on during the OSD.  
+
+<!-- end list -->
+
+2.  At least 2 representatives who can help participants throughout the
+    duration of OSD. The representatives should be able to review and
+    approve pull requests. 
+
+<!-- end list -->
+
+2.  The OSD Committee will work with the selected project to ensure
+    project readiness for OSD. 
+
+<span id="anchor-86"></span>June 3, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez - Chrome Coaster on my desk 
+  - Georg Link -- I’m feeling more centered again today.
+  - Matt Snell - Working on being centered like Georg
+  - Aastha Bist - I am not sure about how I am feeling :)
+  - Mariam Guizani - feeling focused :) 
+  - Saleh Abdel Motaal — I’m here, getting focused still :)
+  - Tharun Ravuri - Feeling Focused
+  - Nicole Huesman -- gearing up for the day
+  - Xiaoya - brainstorming
+  - Kevin Lumbard
+  - Ore-Aruwaji Tola - I was late today, had power downtime 
+
+Video: [*https://youtu.be/p8ZoghoO3K4*](https://youtu.be/p8ZoghoO3K4) 
+
+**Agenda / Notes**:
+
+  - Facilitator next week: Matt G
+
+  - Next Metric Release, last time proposed date was **August 1**
+    
+      - > Metrics released for comments: June 24, 2020
+    
+      - > Public comment Period: June 24 - July 24
+        
+          - **Question: should we include metrics that went through the
+            Continues Metric Contribution cycle into the regular release
+            comment period?**
+    
+      - > Metrics need to be complete for release by July 24
+    
+      - > Move metrics to website and produce PDF: July 24-31
+    
+      - > Metric release 202008 on August 1
+    
+      - > **What do we want ready by then? (PR and Review)**
+        
+          - Documentation Usability
+          - Issue Tracker Inclusivity
+          - Inclusive Leadership
+
+  - Action Item Review:
+    
+      - > **AI Matt Snell: ** Convert the items in the document into
+        > questions.
+        
+          - [*https://docs.google.com/document/d/1\_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing*](https://docs.google.com/document/d/1_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing)
+          - completed
+
+  - Badging update
+    
+      - > Event Criteria & Refining Questions
+        
+          - In Progress -
+            [*https://docs.google.com/document/d/1kn9\_aDntj42l8dgve-IpwcAP75dnjMFCEJFX5tZE9RQ/edit?usp=sharing*](https://docs.google.com/document/d/1kn9_aDntj42l8dgve-IpwcAP75dnjMFCEJFX5tZE9RQ/edit?usp=sharing)
+    
+      - > Review checklist overview -
+        > [*https://docs.google.com/document/d/1huorJVP\_4GKQTeBTwth0aDOv6KOVi8Wh1GrghqpXiO0/edit?usp=sharing*](https://docs.google.com/document/d/1huorJVP_4GKQTeBTwth0aDOv6KOVi8Wh1GrghqpXiO0/edit?usp=sharing)
+    
+      - > Crowdin Vs Weblate
+        
+          - FYI: Weblate metrics will be integrated with GrimoireLab.
+            (Georg)
+
+  - Metric update
+    
+      - > Issue Tracker Inclusivity
+        
+          - Mention “issue tracker” metric
+          - [*https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit\#*](https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit#)
+            
+    
+      - > Inclusive Leadership
+        
+          - [*https://docs.google.com/document/d/1\_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing*](https://docs.google.com/document/d/1_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing)
+    
+      - > Documentation Accessibility
+        
+          - [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+> 
+
+<span id="anchor-87"></span>May 27, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Dawn Foster - feeling like I have too many meetings today :) 
+  - Sean Goggins - Stopping by to catch up\!
+  - Ore-Aruwaji Tola - feeling well today
+  - Matt Snell - Happy to be here, and a little hungry
+  - Nicole Huesman - a little frazzled but very glad to be here\!
+  - Justin W. Flory ([*jwf.io*](https://jwf.io)): Feeling sleepy but
+    happy to join my first CHAOSS D\&I call\!
+  - Mariam Guizani feeling good today :) 
+  - Samantha Lee: Feeling great\! :) 
+  - Georg Link - doing great today :) 
+  - Saleh Abdel Motaal — watching what you’re all up to (ie respectfully
+    stated)
+
+Video: [*https://youtu.be/QTRHjlINsKE*](https://youtu.be/QTRHjlINsKE) 
+
+**Agenda / Notes**:
+
+  - Facilitator next week: Matt Snell (backup Sean Goggins)
+
+  - Inclusive Leadership, proposed metric by Emma Irwin
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/284*](https://github.com/chaoss/wg-diversity-inclusion/pull/284)
+        
+          - Revision gdoc:
+            [*https://docs.google.com/document/d/1\_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing*](https://docs.google.com/document/d/1_GT6HghiYFwGL4KwKZL2lCAdnTc5jBPuIVxLGOmphUw/edit?usp=sharing)
+          - The metric proposal is very prescriptive right now, telling
+            projects what to do.
+          - **AI Matt Snell: ** Convert the items in the document into
+            questions.
+
+  - Update from Oloruntola Ore-Aruwaji
+    
+      - > Tola shared his investigation into Crowdin and what it would
+        > take to translate the badging project.
+
+  - Issue Tracker Inclusivity Metric (first draft from Mariam): 
+    
+      - > [*https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit\#*](https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit#)
+        > 
+    
+      - > Risk is developing a list from 13,000 different repositories
+        > of commonly used labels for issues:
+        > [*https://docs.google.com/spreadsheets/d/1vGze8b\_SiCASarm0S02ntJR53lHud8-5/edit\#gid=714071394*](https://docs.google.com/spreadsheets/d/1vGze8b_SiCASarm0S02ntJR53lHud8-5/edit#gid=714071394)
+        > 
+    
+      - > 
+
+  - Review Documentation Discoverability, Accessibility metrics
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+  - 
+
+<span id="anchor-88"></span>May 20, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez - Ordering more plants for the garden
+  - Matt Snell - Fixed my bike\!\!\! (Had my bike fixed :)
+  - Aastha Bist - In middle of going from Ubuntu 18.04 to 20.04.
+  - Tola  - Ubuntu 20.04 looks cool, A lot of new features
+  - Georg Link - I am happy
+  - Ore-Aruwaji Tola - Chilled 
+  - Xiaoya - So good to see you guys again
+  - Saleh Abdel Motaal — [*I wrote this today… As if I could
+    explain\!*](https://www.quora.com/q/unattended/If-I-were-to-explain)
+
+Video: [*https://youtu.be/uiJ49Qwb3GA*](https://youtu.be/uiJ49Qwb3GA) 
+
+**Agenda / Notes**: 
+
+  - Facilitator next week: Georg Link (Matt G as backup)
+
+  - D\&I Badging Updates 
+    
+      - >  Issue to track Phase one progress -
+        > [*https://github.com/bistaastha/badging-meta/issues/1*](https://github.com/bistaastha/badging-meta/issues/1)
+    
+      - > Updates from Aastha -- Thanks\!
+    
+      - > Assembling a guide to identify milestones to aim for in the
+        > project 
+
+  - Issue Tracker Inclusivity Metric (first draft): 
+    
+      - > [*https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit\#*](https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit#)
+        > 
+
+  - Review Documentation Discoverability, Accessibility metrics
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - Matt PR the first part 
+            
+              - > AI: Move Usability Documentation to a Candidate Metric
+                > 
+
+  - Check in on “Inclusive Leadership” metric by Emma Irwin
+    
+      - > PR:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/284*](https://github.com/chaoss/wg-diversity-inclusion/pull/284)
+    
+      - > Google Doc: 
+
+  - 
+
+<span id="anchor-89"></span>
+
+<span id="anchor-90"></span>
+
+<span id="anchor-91"></span>May 13, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  -  Matt Germonprez - Garden is in\! \[Nicole: Very cool\!\]
+  -  Silona Bonewald - sleepy
+  -  Matt Snell - Feeling chilly today\!
+  -  Amy Marrich - coffee and breakfast time as usual in these:)
+  -  Mariam Guizani - Enjoying coffee :) it’s been so rainy outside
+    these couple of days
+  -  Aastha Bist - Dealing with a bunch of random hardware failures:)
+  - Ore-Aruwaji Tola - Battling with my ISP, it’s been down all day. :)
+  -  Xiaoya Xia - 
+  - Saleh Abdel Motaal — I’m trying to be here and code, maybe I can
+    share
+    [*this*](https://soundcloud.com/sinemachine/enigma-push-the-limits-lounge)
+    instead\!
+  - Nicole Huesman -- A bit of a frazzled morning (working on curriculum
+    for my 9 y/o), but feeling great because I was able to work in my
+    garden late yesterday afternoon
+
+Video: [*https://youtu.be/048qp71ixHQ*](https://youtu.be/048qp71ixHQ) 
+
+**Agenda / Notes**: 
+
+  - Facilitator next week: 
+
+  - Check in on “Inclusive Leadership” metric by Emma Irwin
+    
+      - > PR:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/284*](https://github.com/chaoss/wg-diversity-inclusion/pull/284)
+    
+      - > Google Doc
+
+  - D\&I Badging recommendations from last week
+    
+      - > Recommendation from xiaoya:
+        
+          - Automation (bots?) to read and take “score” on pull requests
+    
+      - > Recommendation from Mariam:
+        
+          - Some people may be intimidated on using GitHub to issue a PR
+            
+              - > Usability is a big consideration. We find many
+                > barriers with pr / issue format but it may be our best
+                > option
+    
+      - > MIT License on Badging
+        
+          - Issue:
+            [*https://github.com/badging/meta/issues/19*](https://github.com/badging/meta/issues/19)
+
+  - Review Documentation Discoverability, Accessibility metrics
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > AI: Move Usability Documentation to a Candidate Metric 
+
+  - Issue Tracker Inclusivity Metric (first draft): 
+    
+      - > [*https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit\#*](https://docs.google.com/document/d/1s0R-ira9guSQU6dVQVV3AOgs2o1VWgJ3kpBbi5WCfPI/edit#)
+        > 
+
+<span id="anchor-92"></span>May 6, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez - I want warmer weather\! 
+  - Samantha Lee - Feeling great today\!
+  - Aastha Bist - Praying that my laptop doesn’t shut off
+  - Kevin Lumbard
+  - Matt Snell - Almost out of finals\!
+  - Ore-Aruwaji Tola - Cold, rain falling heavily 
+
+Aastha: It’s raining here as well
+
+  - Mariam Guizani - Happy to be here :)
+  - Dawn Foster - Happy that my other meeting ended early so I can join
+    part of this one :)
+  - Xiaoya - failed to keep my diet again
+
+Video: [*https://youtu.be/GlTBZ7rjg9I*](https://youtu.be/GlTBZ7rjg9I) 
+
+**Agenda / Notes**: 
+
+  - Facilitator next week: Matt Snell 
+
+  - Review “Inclusive Leadership” metric by Emma Irwin
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/284*](https://github.com/chaoss/wg-diversity-inclusion/pull/284)
+    
+      - > Maybe copy to a gdoc and format with new metric template
+    
+      - > Requires DCO sign-off
+    
+      - > AI: Matt G. to move this to a Google Doc for faster iteration 
+
+  - D\&I Badging Updates 
+    
+      - > Scheduling Meetings 
+    
+      - > In the Community Bonding Meeting 
+    
+      - > Recommendation from xiaoya:
+        
+          - Automation (bots?) to read and take “score” on pull requests
+          - Matt S: Good idea\!
+    
+      - > Recommendation from Mariam:
+        
+          - Some people may be intimidated on using GitHub to issue a PR
+          - Matt S: Good Idea\!
+
+  - Continue developing the Documentation Discoverability
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > Next Documentation Discoverability section to edit is
+        > strategies, specifically surveys (second item in the list) :)
+    
+      - > AI: Saleh will try and create a unified document that lays out
+        > how the three Documentation metrics are connected. 
+
+<span id="anchor-93"></span>April 29, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Amy Marrich - storms are gone and the sun is out
+  - Matt Germonprez - Border Collie is growing up (do agility\!) - we
+    will\!
+  - Georg Link - on Vacation, just relaxing
+  - Matt Snell - Excited for the CHAOSS Podcast\!
+  - Xiaoya - I have just finished another meeting, 2-hour is exhausting
+  - Armstrong 
+  - Nicole Huesman -- feeling energized, just returned from a morning
+    walk\!
+  - Saleh Abdel Motaal 
+
+Video: [*https://youtu.be/44WLBQh7G2I*](https://youtu.be/44WLBQh7G2I) 
+
+**Agenda / Notes**: 
+
+  - Facilitator next week: Matt G (Matt Snell on May 13th)
+
+  - Continue developing the Documentation Usability
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - Starting with Documentation Discoverability
+    
+      - > We revised the description of Documentation Discoverability
+    
+      - > We started on the Strategies
+    
+      - > Next section to edit is surveys (second item in the list) :)
+
+<span id="anchor-94"></span>April 22, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Nicole Huesman
+  - Matt Germonprez - SUNNY\!\!\!
+  - Matt Snell - Learning this new lifestyle
+  - Aastha - Just happy for no particular reason
+  - Amy Marrich - was making breakfast and looking for a missing chicken
+  - Dawn Foster - in a meeting marathon today\!
+  - Igor Steinmacher - sleepy, had no time to think about my mood yet
+    :-)
+  - Georg Link -- I am chill, just relaxed today.
+  - Xiaoya -- Normal day
+  - Saleh Abdel Motaal — Shared [*music from my
+    past*](https://soundcloud.com/sinemachine/sets/exclusive/s-HlQw8) in
+    high bitrate\!
+  - Ore-aruwaji tola - I’m okay
+
+Video: [*https://youtu.be/FHIEeOs5xQU*](https://youtu.be/FHIEeOs5xQU) 
+
+**Agenda / Notes**: 
+
+  - Facilitator next week: Georg Link
+
+  - Hallway track by Stormy:
+    [*https://meet.jit.si/OpenSourceHallwayTrack*](https://meet.jit.si/OpenSourceHallwayTrack)
+    
+      - > ~~We may consider moving our meeting, if Stormy makes this
+        > repeating. Not enough information yet.~~
+    
+      - > Upate from Georg: The hallway track is moving.
+
+  - GSoD participation --
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues/283*](https://github.com/chaoss/wg-diversity-inclusion/issues/283)
+    
+      - > Perhaps include GSoD for documentation for D\&I Badging 
+        
+          - Contributing and Implementer Documentation 
+          - Translation of CHAOSS documents 
+          - Connect with Venu to make the contribution to the GSoD 
+
+  - CHAOSScon session about D\&I -- workshop?
+    
+      - > We need to really consider how something like this would be
+        > delivered virtually
+    
+      - > We also need to keep an eye on what is happening in Texas 
+    
+      - > Perhaps something like a panel would be a bit easier to
+        > translate to a virtual environment 
+    
+      - > **Propose both a workshop and a panel**
+    
+      - > Do we do a whole day of content or do we spread it out? 
+    
+      - > D\&I Badging was accepted to OSSNA
+
+  - Continue developing the Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - Starting with Documentation Utility
+
+**Workspace**:
+
+**May 4 -- date for application, identify mentors for each proposal  
+**See [*Season of Docs
+Timeline*](https://developers.google.com/season-of-docs/docs/timeline)
+
+**Proposal 1**:
+
+Title: **Write a conceptual overview of CHAOSS D\&I metrics and refactor
+existing documentation**
+
+**Description**: Work with CHAOSS D\&I working group members to develop
+a conceptual framing for D\&I metrics. The work so far has focused on
+defining individual metrics, resulting in much detail that is not
+uniformly presented. A technical writer can improve the information
+architecture, revise how a reader can drill down into the details, and
+make it easier to understand D\&I metrics as a whole. The documentation
+would be collected in the CHAOSS D\&I repository and could additionally
+be prepared for other dissemination forms to reach a wider audience. 
+
+**Knowledge/Skills Involved**: Being a good human with good ethics.
+GitHub-Flavored Markdown and Workflow, HTML Inlines/Tables,
+Vector/Raster Images Requirements.
+
+**Aims of the project**: Make the work of the CHAOSS D\&I Working Group
+more available.
+
+**Mentors**: Georg Link
+([*linkgeorg@gmail.com*](mailto:linkgeorg@gmail.com)); Matt Germonprez
+([*germonprez@gmail.com*](mailto:germonprez@gmail.com)) 
+
+**References**: https://github.com/chaoss/wg-diversity-inclusion
+
+**License**: MIT
+
+**Proposal 2**:
+
+**Title**: Build documentation for D\&I Badging project
+
+**Description**: The CHAOSS Diversity and Inclusion Badging Program
+began as a way to ensure that D\&I metrics can have a significant impact
+on the ways that communities function. The aim of the CHAOSS D\&I
+Badging program is to bring D\&I metrics into use for propelling good
+D\&I practices in different open source systems.
+
+This project will focus on framing documentation for the D\&I Badging
+program and aligning it in such a way that it makes sense after
+translation. This work would focus on more community-facing docs related
+to Badging and also on existing Markdown files.
+
+**Knowledge/Skills Involved**: Citizen of the world with editorial
+affinity across languages, GitHub-Flavored Markdown and Workflow, HTML
+Inlines/Tables, Vector/Raster Image Requirements.
+
+**Aims of the project**: Write and structure D\&I Badging documentation.
+Prepare documentation for easy translation.
+
+**Mentors**: **Mentors**: Saleh A.M., Matt S., Aastha Bist
+([*chaoss-badging@googlegroups.com*](mailto:chaoss-badging@googlegroups.com))
+
+**References**:
+[*https://github.com/badging*](https://github.com/badging)
+
+**License**: MIT
+
+**Workspace/Discussion**: 
+
+  - CHAOSScon session about D\&I -- workshop?
+    
+      - > D\&I Badging was accepted to OSSNA
+
+Hold until May to make decision?
+
+Amy can keep an eye on what Austin is doing
+
+Panel discussion -- interaction between people
+
+Propose both -- panel discussion & workshop
+
+Re-think how we structure event -- spread out
+
+<span id="anchor-95"></span>April 15, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Dawn Foster - 
+  -  Matt Germonprez - Tired of cold weather in Omaha. My plants hate it
+  - Amy Marrich - Still no TP
+  - Georg Link - Fun times talking with a teen about the troubling times
+    we live in.
+  - Armstrong Foundjem - 
+  - Matt Snell - Looking forward to a late breakfast :)
+  - Noah Frew - Doing well
+  - Jonah Marz - I'm tired today.
+  - Nicole Huesman - getting better at being a homeschooling mom\!
+  - Aastha - Feeling okay-ish :)
+
+**Video:
+**[***https://youtu.be/frWYXo1E-bs***](https://youtu.be/frWYXo1E-bs)**
+**
+
+**Agenda / Notes: **
+
+  - Google Season of Docs 
+    
+      - > Perhaps submit at the CHAOSS project (not under the LF)
+        
+          - Also social media excitement to be applying:)
+
+  - Outreachy 
+    
+      - > Likely (hopefully) associated with D\&I badging
+    
+      - > Hopefully we’ll get 1 candidate
+        
+          - Possibly 70% from CHAOSSCast to support the casting and the
+            rest to support a candidate for 2021
+          - Propose a similar arrangement with events
+          - Make up any missing candidate money with a corporate
+            sponsorship
+    
+      - > Maybe keep a list of Open Source “internships”
+        
+          - [*https://opensourcediversity.org/*](https://opensourcediversity.org/)
+            -- has a list of “programs”
+          - [*https://github.com/tapaswenipathak/Open-Source-Programs*](https://github.com/tapaswenipathak/Open-Source-Programs)
+            
+
+  - Continue developing the Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+        
+          - MattG will look through all the resources for each section
+          - Documentation Usability section completed except resources
+    
+      - > Discussed when to add to Github and how to break it out into
+        > Github
+    
+      - > Iterating on a doc is hard in Github 
+
+  - Facilitator next week: Nicole with MattG as backup
+
+<span id="anchor-96"></span>
+
+<span id="anchor-97"></span>April 8, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+1.  Ore-aruwaji tola - feeling better
+2.  Matt Germonprez - I have eggs. 
+3.  Silona - kitties are playing\!
+4.  Matt Snell - Contributing\!
+5.  Amy Marrich - I have chickens\!:)
+6.  Georg Link - Excited to go to the fish store today to get 🐠
+7.  Aastha Bist - A bit sleepy after a heavy dinner
+8.  Daniel Izquierdo
+9.  Kevin Lumbard
+10. Daniel Por - I’ve lost sense of time
+11. Sarah Brooks - I got to see pretty flowers this morning :)
+12. Nicole Huesman -- happy to be here, but need to drop at bottom of
+    hour (I’ve had a weekly conflict that will end this week -- yay --
+    excited that it will end this week\!)
+13. xiaoya - Made several cuisines by myself and had a good lunch\!
+14. Saleh Abdel Motaal — I think I am here, but not my brain\!
+15. Jilayne Lovejoy - ditto on Saleh’s comment :)
+16. Yutong zhu
+17. haoyue Wang
+18. 
+
+Video: [*https://youtu.be/ncMVbSFL-uo*](https://youtu.be/ncMVbSFL-uo) 
+
+Agenda Items / Notes:
+
+  - Community Manager Position 
+
+  - D\&I Badging — [*Bi-weekly Issue
+    (\#18)*](https://github.com/badging/meta/issues/18)![](Pictures/10000000000004B00000038D2DEA2970CE55C18C.jpg)
+    
+      - > Proposal Review; They are all submitted\!
+    
+      - > A simple [*GitLab parity
+        > document*](https://docs.google.com/document/d/1r4j5VmgxA_WXiGkx7XYfdzHUIX46hs0ziqErE59CxNQ/edit?usp=sharing)
+        > - Matt
+    
+      - > Adding details to
+        > [*badging-template*](https://github.com/badging/badging-template)
+    
+      - > Working on proof of concept 
+    
+      - > Looking to address longer term aspects 
+        
+          - Gaming 
+          - Governance 
+          - Trust Building 
+    
+      - > Move to GitLab? How would we transition something from GitHub
+        > to GitLab when we are unsure of what the process looks like
+        > --- Looking to maintain momentum with work in GitHub 
+    
+      - > Badging Templates
+        
+          - [*https://github.com/badging/badging-template*](https://github.com/badging/badging-template)
+            
+    
+      - > Sample workflow
+        
+          - It has been modeled 
+        
+          - Building up documentation to assist in the badging process 
+            
+              - > Provide translation of the documentation 
+            
+              - > Considering Crowdin
+        
+          - Development of bots to help in the process -- making sure
+            not to create more noise or confusion
+    
+      - > Questions 
+        
+          - How to ensure that the number of reviewers are appropriate? 
+          - How are the thresholds being met for the badges? 
+          - How can we make sure that people can post concerns after a
+            badge is awarded? 
+          - How can the D\&I WG participate in the badging process? 
+
+  - We could continue developing the Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > Discussed when to add to Github and how to break it out into
+        > Github
+    
+      - > Iterating on a doc is hard in Github 
+
+  - Who will be facilitator next week?
+    
+      - > Amy Marrich, backup: Matt G.
+
+<span id="anchor-98"></span>April 1, 2020
+
+**Attendees** (please add yourself and let us know how you are feeling
+today):
+
+  - Dawn Foster - it’s been a hectic day
+  - Aastha Bist - mostly I’m good
+  - Armstrong Foundjem -- good weather here
+  - Matt S. - Still Sleepy?\!?
+  - Silona - “coworkers” are finally awake. Maybe they will make an
+    appearance on the call. 
+  - Georg Link - I added plants to my aquarium, can’t wait to add
+    fish![](Pictures/1000020100000502000003C292AA98176CCC4F43.png)
+  - Esther Xia - fixed a problem on my assignment and have a feeling of
+    achievement 
+  - Saleh Abdel Motaal — having really bad memories from Layout &
+    Typography 101
+  - Tianyi Chow - quite late in my time, tired but excited
+  - Frank Zhao - Very first time here, want to learn
+  - Haoyue Wang - finished the delivery of an article and feel relaxed
+  - Heming - Very first time here, interesting
+  - Jerry Fan — …
+  - Amy Marrich - weather is nice and the fridge has food
+  - Daniel: each time I buy food, there’s a small crisis around
+    wondering how to properly clean everything...
+
+Video: [*https://youtu.be/BLf0GNrmsWU*](https://youtu.be/BLf0GNrmsWU) 
+
+Agenda items / Notes:
+
+  - Facilitator: Georg
+
+  - Facilitator next week: Silona
+
+  - From last week:
+    
+      - > Work the Implementation section in Documentation Accessibility
+        
+          - [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+          - The whole document has become rather complex with all the
+            different objectives we identified.
+          - It would be good to separate the objectives into logical
+            groups and then have matching data collection strategies.
+          - the goal is to have more manageable document that does not
+            confuse the reader
+          - There may be an overlap between the objectives. 
+
+  - 
+
+<span id="anchor-99"></span>March 25, 2020
+
+Attendees (please add yourself and let us know how you are feeling
+today):
+
+  - Georg Link - excited about my new aquarium 🐟🐠
+    
+      - > ![](Pictures/10000000000009C4000007530A5674A7E7FC6AE2.jpg)
+
+  - Dawn Foster - tired and a little stir-crazy 🤪
+
+  - Aastha - somewhat positive
+
+  - Matt Snell - Socially Distancing
+
+  - Silona Bonewald - tired of arguing w stupid on the internet (yes i
+    know better :-P)
+
+  - Matt Germonprez - Jealous of people with chickens
+
+  - Nicole Huesman - tired but trying to muster my energy, somewhat
+    stir-crazy :)
+
+  - Saleh Abdel Motaal — We’ll I’m 75% certain it was not COVID :)
+
+  - Amy Marrich - Making the best of the situation
+
+  - King Gao
+
+Video: [*https://youtu.be/U\_8gGQXfSaU*](https://youtu.be/U_8gGQXfSaU) 
+
+Agenda items / Notes:
+
+  - Work the Implementation section in Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > The whole document has become rather complex with all the
+        > different objectives we identified.
+    
+      - > It would be good to separate the objectives into logical
+        > groups and then have matching data collection strategies.
+    
+      - > the goal is to have more manageable document that does not
+        > confuse the reader
+    
+      - > There may be an overlap between the objectives. 
+
+  - D\&I Badging Update
+    
+      - > Badge-athons
+    
+      - > Office Hours
+    
+      - > Discuss Aastha’s Project Idea doc
+        
+          - [*https://docs.google.com/document/d/1zMh-DwCSpc3FjS7YXkdJ2PsTN0YLXvaTo-uXpBNNwTA/*](https://docs.google.com/document/d/1zMh-DwCSpc3FjS7YXkdJ2PsTN0YLXvaTo-uXpBNNwTA/)
+          - Mindmap:
+            [*https://app.mindmup.com/map/\_free/2020/03/3ea73ad06c4d11ea8e0a55c24aa01853*](https://app.mindmup.com/map/_free/2020/03/3ea73ad06c4d11ea8e0a55c24aa01853)
+          - 
+    
+      - > Discuss @CHAOSS/Branding
+        
+          - Working LF folks to work out the logos/badges 
+          - [*https://en.wikipedia.org/wiki/Mozilla\_Open\_Badges*](https://en.wikipedia.org/wiki/Mozilla_Open_Badges)
+            
+          - [*https://openbadges.org/*](https://openbadges.org/) 
+          - ![](Pictures/10000201000002210000016421E6289DAF8B14D9.png)
+          - CII Best Practices Badge:
+            [*https://bestpractices.coreinfrastructure.org/en*](https://bestpractices.coreinfrastructure.org/en)
+    
+      - > Building out the workflow -- something that is still in
+        > progress 
+        
+          - [*https://app.mindmup.com/map/\_free/2020/03/3ea73ad06c4d11ea8e0a55c24aa01853*](https://app.mindmup.com/map/_free/2020/03/3ea73ad06c4d11ea8e0a55c24aa01853) 
+            
+
+<span id="anchor-100"></span>March 18, 2020
+
+Attendees (please add yourself and let us know how you are feeling
+today):
+
+  - Matt Germonprez, I got a
+    puppy![](Pictures/1000000000000753000009C4C76D56DF32692212.jpg)
+  - Dawn Foster - Learning the ups and downs of WFH home full time WITH
+    my partner\! 🤪
+  - Silona Bonewald - sleepy
+  - Daniel Izquierdo - having tea, relaxed
+  - Aastha Bist - feeling healthy
+  - Georg Link - tired of being home all day 🏡 
+  - Jilayne Lovejoy - (joined late after having trouble and fearing that
+    Zoom is overloaded) new dog adoption here, learning training (for hu
+    ![](Pictures/10000000000009C4000007531C380FAB4C9627FD.jpg)(photo
+    added from mobile Docs app\!)
+  - Saleh Abdel Motaal — I’ll keep my mic off, just in case, or keep
+    your distance
+  - Nicole Huesman -- juggling meetings as we simultaneously
+    “homeschool” our kiddo :) 
+
+Video: [*https://youtu.be/-mFWB5l2VdI*](https://youtu.be/-mFWB5l2VdI) 
+
+Notes:
+
+  - Start meeting with Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+  - Diversity & Inclusion Badging 
+    
+      - > Broad Feedback asked for -- if we have time
+
+  - 
+
+  - 
+
+  -  
+
+<span id="anchor-101"></span>March 11, 2020
+
+Attendees: 
+
+  - Saleh Abdel Motaal, 
+  - Dawn Foster, 
+  - Matt Germonprez, 
+  - Jilayne Lovejoy, 
+  - Georg Link, 
+  - Silona Bonewald, 
+  - Armstrong, 
+  - Aastha
+
+Video: [*https://youtu.be/IEXS0TS9SGw*](https://youtu.be/IEXS0TS9SGw) 
+
+Notes:
+
+  - D\&I Travel Dollars
+    
+      - > Sean Goggins and Matt Germonprez got a MOSS grant to support
+        > the D\&I work, support students, support travel. Part of the
+        > budget is for folks also in the CHAOSS community.
+        
+          - Use of money/goal: Travel for people to go talk at events,
+            but also to help event organizers make their event meet
+            CHAOSS metrics
+    
+      - > Idea to have some matching dollars and find more funding for
+        > CHAOSS member travel.
+    
+      - > If ask for “matching dollars” - need a “pitch deck: of what
+        > the money will be used for, how much are we asking for, how to
+        > give the money, what does supporters “get” - reports on
+        > impact, logo on page, ??
+    
+      - > Alternative is also a LF travel fund:
+        > [*https://events19.linuxfoundation.org/travel-fund-request/*](https://events19.linuxfoundation.org/travel-fund-request/)
+    
+      - > **AI Matt:** ask event team for possibility of matching.
+    
+      - > Is there a budget, target or goal?
+        
+          - Put together a one-page prospectus? Or “pitch deck: of what
+            the money will be used for, how much are we asking for, how
+            to give the money, what does supporters “get” - reports on
+            impact, logo on page, ??
+          - What are the rules for obtaining the funds?
+          - How will this be advertise? Will we have a website for this?
+          - Will there be a reporting of how the dollars were
+            successfully used and how it made an impact.
+
+  - Talk about the badging progress every other week
+    
+      - > Badge-a-thons —
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/277*](https://github.com/chaoss/wg-diversity-inclusion/issues/277)
+    
+      - > Tracking badging issues —
+        > [*https://github.com/badging/meta/issues*](https://github.com/badging/meta/issues)
+    
+      - > Outreachy interested interns — See [*Chore: Open draft PR for
+        > Event Badge —
+        > @thecraftman*](https://github.com/badging/meta/issues/6).
+    
+      - > Sync-up with LF later today—
+        > [*https://github.com/badging/meta/issues/5*](https://github.com/badging/meta/issues/5)
+    
+      - > Badging Project Board —
+        > [*https://github.com/badging/meta/projects/1*](https://github.com/badging/meta/projects/1)
+        
+          - Current Bi-Weekly Agenda card —
+            [*https://github.com/badging/meta/projects/1\#card-33651241*](https://github.com/badging/meta/projects/1#card-33651241)
+        
+          - Branding card —
+            [*https://github.com/badging/meta/projects/1\#card-33892562*](https://github.com/badging/meta/projects/1#card-33892562)
+            
+              - > Propose the idea for @CHAOSS/branding and
+                > @Badging/branding
+        
+          - Next Bi-Weekly Agenda card —
+            [*https://github.com/badging/meta/projects/1\#card-34080975*](https://github.com/badging/meta/projects/1#card-34080975)
+    
+      - > Create CHAOSS/branding repo for maintaining the CHAOSS assets
+        
+          - Public facing:
+            [*https://chaoss.community/media/*](https://chaoss.community/media/)
+          - Workflow in:
+            [*https://github.com/chaoss/governance/*](https://github.com/chaoss/governance/)
+          - Need to get missing assets from LF, like an SVG file of our
+            logo.
+    
+      - > Working with Steve Winslow from LF on the legal framework for
+        > the “conformance program” / badging program.
+    
+      - > Steve Winslow asking LF to create a “conformance badge” that
+        > looks familiar to other LF conformance badges.
+    
+      - > Still working on the balance of badge requester self reporting
+        > and checking by the community.
+    
+      - > [*Will the D\&I Badging move to GitLab as well if CHAOSS
+        > migrates?*](https://docs.google.com/document/d/1a5_mRWmWBE0yRm8lgBi0myEW7YwfRSgF9pQGR1_IPK0/edit?ts=5e688522#heading=h.l9e0lnkuo74k)
+        
+          - has not been discussed yet. might consider moving as well
+
+  - Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+<span id="anchor-102"></span>March 3, 2020
+
+Attendees: 
+
+  - Saleh Abdel Motaal, 
+  - Aastha, 
+  - Georg Link, 
+  - Nicole Huesman, 
+  - Jilayne Lovejoy, 
+  - Matt Germonprez
+
+Video: [*https://youtu.be/2fqgb9l\_O78*](https://youtu.be/2fqgb9l_O78) 
+
+Notes:
+
+  - Talk about the badging progress every other week
+
+  - D\&I Panel at the LF Member Summit, we are looking for new panelists
+    
+      - > Nicole and Dawn had to drop out due to corporate travel
+        > restrictions
+    
+      - > [*https://docs.google.com/document/d/12wOblvmofMGAKupjlG9W08kLGB4Y2Avm4PjE6l9po\_8/edit*](https://docs.google.com/document/d/12wOblvmofMGAKupjlG9W08kLGB4Y2Avm4PjE6l9po_8/edit)
+    
+      - > **AI Georg:** send email to ask for panelists.
+        
+          - CHAOSS list
+          - D\&I in OSS list 
+          - OpenSourceDiversity forum
+
+  - Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+
+<span id="anchor-103"></span>February 26, 2020
+
+Attendees: 
+
+  - Armstrong, 
+  - Jilayne Lovejoy, 
+  - Aastha Bist, 
+  - Saleh Abdel Motaal, 
+  - Georg Link, 
+  - Matt Snell, 
+  - Amy, 
+  - Daniel Izquierdo
+
+Video: [*https://youtu.be/iJAZSFE\_6M8*](https://youtu.be/iJAZSFE_6M8) 
+
+Notes:
+
+  - Introductions of new attendees
+    
+      - > Jilayne Lovejoy
+    
+      - > Aastha Bist, working on micro-task for GSoC on the badging
+        > project
+
+  - Badging project
+    
+      - > [*Sundays bi-weekly 3-h “badge-o-thon”
+        > sessions*](https://github.com/chaoss/wg-diversity-inclusion/issues/277)
+        > invite, next meeting is this week
+    
+      - > GSoC microtasks question. (Posten in
+        > badging/diversity-and-inclusion issue \#1)
+        
+          - In Q 0 of the microtask, there's the term 'software badge'
+            which has been used. It is in relation to badges created
+            using IMS standards. The question itself is about how the
+            IMS standards can be helpful in creating a software
+            badge.  I have a doubt about what that term might refer
+            to. Does it refer to an independent badge? Or is it more
+            like creation of a badge which is associated with a
+            particular software's metadata?
+
+  - Metrics:
+    
+      - > Spreadsheet used to coordinate the work across working groups:
+        > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+    
+      - > Template used for creating individual metrics:
+        > [*https://github.com/chaoss/metrics/blob/master/activity-metrics/metric-template.md*](https://github.com/chaoss/metrics/blob/master/activity-metrics/metric-template.md)
+
+  - Documentation Accessibility
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > Saleh will open an issue for future refinements needed to
+        > better survey finer-grained causes for friction across both
+        > the project’s membership and all prospective members in the
+        > community at large.
+    
+      - > Jilayne raises the great question, how do you measure
+        > subjective aspects which are inherently biased to the author’s
+        > own frame of reference… structure, jargon… etc.
+    
+      - > We revised the metric and added a few data collection
+        > strategies.
+    
+      - > We left at this unresolved comment:
+        > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit?pli=1\&disco=AAAAJIMH5mQ*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit?pli=1&disco=AAAAJIMH5mQ)
+
+<span id="anchor-104"></span>February 19, 2020
+
+Attendees: Georg Link, Matt Snell, Ange, Saleh A. M., Dawn Foster, Matt
+Germonprez, Amy Marrich, Emma
+
+Video: 
+
+Part 1: [*https://youtu.be/qxrRUzH\_DTo*](https://youtu.be/qxrRUzH_DTo) 
+
+Part 2: [*https://youtu.be/ZEJh\_l2GiWM*](https://youtu.be/ZEJh_l2GiWM) 
+
+Notes:
+
+  - Reflect on Metric Release
+    
+      - > Take a look at the metric release and think towards the future
+        > for next release
+    
+      - > [*https://chaoss.community/metrics/*](https://chaoss.community/metrics/)
+        > 
+    
+      - > Sponsorship 
+        
+          - Capacity Differences of contributors
+          - How we might want to consider to include capacity
+            differences
+          - Sponsorship is about empowerment, especially when protégés
+            have differences
+    
+      - > New metrics? 
+        
+          - [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+            
+    
+      - > How are released metrics being validated and tested?
+        
+          - Proposal from Emma for a Toolkit:
+            [*https://github.com/chaoss/wg-diversity-inclusion/issues/252*](https://github.com/chaoss/wg-diversity-inclusion/issues/252)
+        
+          - Maybe ask users of metrics to write a blog post to share
+            their experiences.
+            
+              - > Idea for a blog post series
+                > [*https://docs.google.com/document/d/1p9FZM6rixjiEsxXQ7Ij-mbGCJKm\_OrOQ6nd3oIBRnto/edit\#heading=h.i08ikslakwjv*](https://docs.google.com/document/d/1p9FZM6rixjiEsxXQ7Ij-mbGCJKm_OrOQ6nd3oIBRnto/edit#heading=h.i08ikslakwjv)
+            
+              - > Podcast as another venue for this.
+        
+          - How are people collecting metrics and feeding them into
+            systems for using the metrics?
+            
+              - > There is currently a disconnect between collecting a
+                > metric and how to roll it out and put data back into
+                > “the system”
+    
+      - > Where are the metrics implemented? Augur or GrimoireLab?
+        
+          - Augur and GrimoireLab are not implementing D\&I metrics
+            right now.
+          - D\&I Badging would be an implementation in the future
+          - Emma’s Toolkit proposal promises to be an easy way for
+            people to deploy the metrics in their own projects.
+
+  - D\&I Badging Process (Matt S., and Saleh A. M.)
+    
+      - > The idea is to give projects who work with D\&I metrics to
+        > show recognition on their repos and websites that they are
+        > proud to use CHAOSS D\&I metrics. The Badging for events is
+        > the next step in which a minimum standard will be ensured.
+    
+      - > Work will be done in:
+        > [*https://github.com/Nebrethar/Docs-Diversity-Inclusion-Badging*](https://github.com/Nebrethar/Docs-Diversity-Inclusion-Badging)
+    
+      - > The Badging process was thinking to be through a GitHub Issue
+        > at first
+    
+      - > Other approach could be through a pull request, so that we
+        > have a permanent history and documentation.
+    
+      - > Two different badges: (i) for events; (ii) for projects.
+    
+      - > The templates match up to the released metrics. It seems that
+        > we have the basic elements in place.
+    
+      - > The separation of badges into events and projects makes sense
+        > for OpenStack project (Amy’s feedback)
+    
+      - > When a PR is made, it has two components: 
+        
+          - 1\. a markdown page that is based on the template
+          - 2\. an entry in the list of passing badges (and linking to
+            the markdown file)
+    
+      - > Implementation question? Will we be passing out badges or
+        > providing a link?
+        
+          - How will we make sure that people displaying a badge are
+            conforming?
+          - We need to explore technical implementation.
+          - Possibly use the CII best practices badge app?
+          - [*https://bestpractices.coreinfrastructure.org/en/projects*](https://bestpractices.coreinfrastructure.org/en/projects)
+          - We could change the criteria for the D\&I badging
+            requirements
+          - If we want the PR process, then maybe we could enter a
+            project into a customized version of the Best Practices
+            Badge system.
+    
+      - > Maybe we will walk through the badging process in a future
+        > meeting.
+
+<span id="anchor-105"></span>February 9, 2020
+
+Attendees: Georg Link, Maria Cruz
+
+Agenda:
+
+  - New meeting time proposed for: Wednesdays 10am CST.
+
+<span id="anchor-106"></span>January 20, 2020
+
+Attendees: Matt G. Matt S., Kevin L., Dawn F., Saleh A. M., 
+
+Video: [*https://youtu.be/lqJ3tQdwbeM*](https://youtu.be/lqJ3tQdwbeM) 
+
+Notes:
+
+  - Metrics Release. Used time to address metrics issues: 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+        > 
+    
+      - > AI: Matt fix the issues and tag people for the PRs 
+
+  - D\&I Badging Program 
+    
+      - > [*https://github.com/Nebrethar/Docs-Diversity-Inclusion-Badging*](https://github.com/Nebrethar/Docs-Diversity-Inclusion-Badging)
+    
+      - > Issue Templates in progress
+    
+      - > Matt:
+        
+          - Good start
+          - Must be less detailed
+          - “Are you measuring this, and how?”
+
+  - Outreachy 
+
+  - Perhaps find a time
+
+<span id="anchor-107"></span>January 6, 2020
+
+Note: Dawn and Saleh were the only attendees, so we canceled the meeting
+after 15 min :)
+
+<span id="anchor-108"></span>
+
+<span id="anchor-109"></span>December 16, 2019
+
+Attendees: Matt S., Georg L., Saleh M.
+
+Video: not recorded
+
+Notes:
+
+  - No meetings December 23, 30. We meet next again January 6.
+
+  - Christmas party during the call
+
+  - Tracking Spreadsheet:
+    [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit)
+
+  - Documentation metric:
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#)
+    
+      - > AI Saleh: create a PR for this metric
+
+<span id="anchor-110"></span>December 9, 2019
+
+Attendees; Matt G., Matt S., Saleh M., Georg L., Nicole 
+
+Video:[*https://studio.youtube.com/video/77QXd3oehLM/edit*](https://studio.youtube.com/video/77QXd3oehLM/edit)
+
+Notes:
+
+  - No meetings December 23, 30. After next week, we meet again January
+    6.
+
+  - Tracking Spreadsheet:
+    [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit)
+    
+      - > Link to markdown page from the sheet
+
+  - Should we release the Demographic Dimensions page as an appendix to
+    the metrics?
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data*](https://github.com/chaoss/wg-diversity-inclusion/tree/master/demographic-data)
+    
+      - > We asked if Nikki would be willing to maintain this as part of
+        > her project.
+        
+          - https://github.com/drnikki/open-demographics/issues/64
+
+  - Updated mentorship metric to new template
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/248*](https://github.com/chaoss/wg-diversity-inclusion/pull/248)
+
+  - Worked on Documentation:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/70*](https://github.com/chaoss/wg-diversity-inclusion/issues/70)
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > 
+
+<span id="anchor-111"></span>December 2, 2019
+
+Attendees: Dawn, Georg, Matt G, Matt S.
+
+Video: [*https://youtu.be/W3\_4CX\_4TIs*](https://youtu.be/W3_4CX_4TIs) 
+
+Notes:
+
+  - **AI Georg and Matt:** submit a talk to SCALE 18x
+    
+      - > did not submit
+
+  - Accepted new metric: Sponsorship ([*PR
+    \#243*](https://github.com/chaoss/wg-diversity-inclusion/pull/243))
+    
+      - > based on
+        > [*https://docs.google.com/document/d/1J-9f\_wYQxP26L\_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit\#heading=h.cxovrypq9lne*](https://docs.google.com/document/d/1J-9f_wYQxP26L_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit#heading=h.cxovrypq9lne)
+
+  - Tracking Spreadsheet:
+    [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit)
+
+  - Worked on Governance: Board Diversity:
+    
+      - > [*https://docs.google.com/document/d/13toY8vWR5OGwiuLKzI7cmhnjqc7H8L9u-iUyRmE9egg/edit\#*](https://docs.google.com/document/d/13toY8vWR5OGwiuLKzI7cmhnjqc7H8L9u-iUyRmE9egg/edit#)
+    
+      - > created a pr:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/244*](https://github.com/chaoss/wg-diversity-inclusion/pull/244)
+
+  - Worked on Documentation:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/70*](https://github.com/chaoss/wg-diversity-inclusion/issues/70)
+    
+      - > [*https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit\#heading=h.7c8aneuch0wb*](https://docs.google.com/document/d/1OaKDksmuoi6nhaduZ4F96mTwQJvIFnfI8BqLx4MRO38/edit#heading=h.7c8aneuch0wb)
+    
+      - > References:
+        
+          - W3C WCAG —
+            [*https://www.w3.org/WAI/standards-guidelines/wcag/*](https://www.w3.org/WAI/standards-guidelines/wcag/)
+            
+              - > WCAG 2.1 (2018) —
+                > [*https://www.w3.org/TR/WCAG21/\#comparison-with-wcag-2-0*](https://www.w3.org/TR/WCAG21/#comparison-with-wcag-2-0)
+            
+              - > WCAG 2.2 (Due) —
+                > [*https://www.w3.org/WAI/GL/project*](https://www.w3.org/WAI/GL/project)
+    
+      - > It seems like we need to create multiple metrics around
+        > Documentation Inclusivity
+        
+          - tools used for documentation
+          - accessibility guidelines of online resources
+          - the structure and content of the documentation
+
+<span id="anchor-112"></span>November 25, 2019
+
+Attendees: Saleh A., Georg, Matt S., Sean, Dawn
+
+Video: [*https://youtu.be/VTRN-EsQzlU*](https://youtu.be/VTRN-EsQzlU) 
+
+Notes:
+
+  - SCALE 18x
+    
+      - > Matt S. and Georg are interested in doing something
+    
+      - > What about a workshop with an option for remote participation
+        
+          - Maybe use Zoom breakout rooms for workshops
+    
+      - > Two options of what we have done before:
+        
+          - Workshop on D\&I metrics
+        
+          - How to produce a D\&I report
+            
+              - > **AI Georg and Matt:** submit a talk
+
+  - Review PRs:
+    
+      - > [*\#239*](https://github.com/chaoss/wg-diversity-inclusion/pull/239)
+    
+      - > [*\#238*](https://github.com/chaoss/wg-diversity-inclusion/pull/238)
+
+  - Tracking Spreadsheet:
+    [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=276406255)
+
+  - Metrics to focus on next:
+    
+      - > Sponsorship ([PR
+        > \#243](https://github.com/chaoss/wg-diversity-inclusion/pull/243))
+        
+          - [*https://docs.google.com/document/d/1J-9f\_wYQxP26L\_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit\#heading=h.cxovrypq9lne*](https://docs.google.com/document/d/1J-9f_wYQxP26L_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit#heading=h.cxovrypq9lne)
+    
+      - > Board/Council Diversity
+    
+      - > Documentation
+
+<span id="anchor-113"></span>November 18, 2019
+
+Attendees: Georg L., Matt S., Matt G., Daniel I., Sean G., Saleh A. 
+
+Video: [*https://youtu.be/vcTr\_N0wWlY*](https://youtu.be/vcTr_N0wWlY) 
+
+Notes:
+
+  - D\&I Badging Update
+    
+      - > Matt Snell got University funding to build a prototype, and he
+        > will talk about it by CHAOSScon EU 2020.
+    
+      - > Includes a software component that builds the badge and for
+        > tracking evidence.
+    
+      - > The process for getting a badge is inspired by
+        > [*https://joss.theoj.org/*](https://joss.theoj.org/) 
+    
+      - > Projects have to submit a request including evidence and be
+        > peer-reviewed
+    
+      - > A challenge will be to find editors and reviewers
+
+  - Attendee Demographics google doc:
+    [*https://docs.google.com/document/d/1psK\_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing*](https://docs.google.com/document/d/1psK_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing)
+    
+      - > Raised a point that the Likert scale could be an Emoji scale
+        > in particular cases. 
+    
+      - > PR:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/238*](https://github.com/chaoss/wg-diversity-inclusion/pull/238)
+
+  - Speaker Demographics google doc:
+    [*https://docs.google.com/document/d/17Lc7cn2c18OP-nEDB2ioJ2bOIDRy2SEFju-42zJNDeI/edit?usp=sharing*](https://docs.google.com/document/d/17Lc7cn2c18OP-nEDB2ioJ2bOIDRy2SEFju-42zJNDeI/edit?usp=sharing)
+    
+      - > PR:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/239*](https://github.com/chaoss/wg-diversity-inclusion/pull/239)
+
+  - Tracking Spreadsheet:
+    [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=276406255*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=276406255)
+    
+
+  - Diversity and delivery of talk - event metric
+    
+      - > Does an event have interpreters?
+    
+      - > Does an event have screens to show live transcripts of what
+        > speakers say on a screen to attendees?
+    
+      - > Does an event have sign-language experts translating 
+
+<span id="anchor-114"></span>November 11, 2019
+
+Agenda:
+
+  - D\&I badging project for events
+  - Attendee demographics
+  - NodeJS questions into CHAOSS metrics framework and build new
+    questions
+
+Attendees:
+
+  - Georg L, Saleh A. Motaal, Saulo N., Matt S.
+
+Video: [*https://youtu.be/fdsyIcLloiY*](https://youtu.be/fdsyIcLloiY) 
+
+Notes:
+
+  - D\&I badging project for events will be happening
+    
+      - > The goal is to establish a badging program for events
+    
+      - > Start probably in spring for a prototype
+    
+      - > Proposal (accepted):
+        
+          - [*https://docdro.id/WzcXl2O*](https://docdro.id/WzcXl2O)
+
+  - Attendee demographics:
+    [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/attendee-demographics.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/attendee-demographics.md)
+    
+    
+      - > reopened:
+        > [*\#84*](https://github.com/chaoss/wg-diversity-inclusion/issues/84)
+    
+      - > development in google doc:
+        > [*https://docs.google.com/document/d/1psK\_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing*](https://docs.google.com/document/d/1psK_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing)
+
+  - 
+
+<span id="anchor-115"></span>November 4, 2019
+
+Video: [*https://youtu.be/SsCmf73KqaI*](https://youtu.be/SsCmf73KqaI) 
+
+Agenda:
+
+  - Do more work on event metrics for release
+  - Issues review and replies
+  - Apache Survey
+
+Notes:
+
+  - Attendees: Saleh Abdel Motaal, Matt G. Georg L., Amy, Kevin, L.
+
+  - Saleh introduced himself, one of two folks behind a new Node.js
+    initiative
+    ([*\#235*](https://github.com/chaoss/wg-diversity-inclusion/issues/235))
+    
+    
+      - > Wants to see and recognize different kinds of contributions in
+        > the Node.js community
+    
+      - > Goal: understand accessibility beyond screen readers. Can
+        > people participate in ongoing conversations?
+    
+      - > Tools to coordinate efforts in a community are geared towards
+        > people who don’t have accessibility issues. Communities that
+        > have accessibility needs have a harder time using the tools we
+        > use in open source projects. 
+    
+      - > Annual Node.js survey. Added questions related to D\&I:
+        
+          - [*https://docs.google.com/document/d/1XAc-Vaw\_caz\_1NF0gTY4CLoDpfrrreJOgQ6rxlEjKSw/edit*](https://docs.google.com/document/d/1XAc-Vaw_caz_1NF0gTY4CLoDpfrrreJOgQ6rxlEjKSw/edit)
+
+  - Update metrics to new templates
+    
+      - > Matt has been submitting pull requests
+    
+      - > Minor edit required in:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/pull/233*](https://github.com/chaoss/wg-diversity-inclusion/pull/233)
+
+  - We reviewed the GQM approach we have
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/tree/master/focus-areas*](https://github.com/chaoss/wg-diversity-inclusion/tree/master/focus-areas)
+
+  - Apache Survey
+    
+      - > [*https://docs.google.com/document/d/1dfyMZ58ZENOO21sZvj\_\_g1fjIP-BJfDuIECt066Dsuc/edit\#heading=h.sg1timhl5ked*](https://docs.google.com/document/d/1dfyMZ58ZENOO21sZvj__g1fjIP-BJfDuIECt066Dsuc/edit#heading=h.sg1timhl5ked)
+    
+      - > The survey development is inspired by the CHAOSS D\&I WG work
+        > we have.
+    
+      - > Questions have been tweaked to fit the ASF project.
+    
+      - > Question: Will there be a report on how the analysis of the
+        > survey was done?
+
+  - Overview of the surveys we collected:
+    
+      - > [*https://docs.google.com/document/d/1GsGdfr4eqbh\_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit\#*](https://docs.google.com/document/d/1GsGdfr4eqbh_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit#)
+
+  - D\&I badging of events
+    
+      - > Attendee demographics:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/attendee-demographics.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/attendee-demographics.md)
+        > 
+        
+          - reopened:
+            [*\#84*](https://github.com/chaoss/wg-diversity-inclusion/issues/84)
+          - development in google doc:
+            [*https://docs.google.com/document/d/1psK\_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing*](https://docs.google.com/document/d/1psK_UH5uLeiVHagpoJbCtm8dF1nIshfCx6qXXJWe4yc/edit?usp=sharing)
+    
+      - > Speaker demographics:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/speaker-demographics.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/speaker-demographics.md)
+        
+          - reopened
+            [*\#83*](https://github.com/chaoss/wg-diversity-inclusion/issues/83)
+          - development in google doc:
+            [*https://docs.google.com/document/d/17Lc7cn2c18OP-nEDB2ioJ2bOIDRy2SEFju-42zJNDeI/edit?usp=sharing*](https://docs.google.com/document/d/17Lc7cn2c18OP-nEDB2ioJ2bOIDRy2SEFju-42zJNDeI/edit?usp=sharing)
+    
+      - > We worked on Attendee Demographics
+
+<span id="anchor-116"></span>
+
+<span id="anchor-117"></span>October 28, 2019 - Cancelled due to
+OSSummit.
+
+<span id="anchor-118"></span>October 21, 2019
+
+Agenda:
+
+  - Issues review and replies
+
+Attendees: Dawn, Matt G., Daniel, Kevin, Nicole 
+
+Video: [*https://youtu.be/xt0MOw4\_8e0*](https://youtu.be/xt0MOw4_8e0) 
+
+Notes:
+
+  - New PR to update metrics to template for Code of Conduct metric -
+    merged.
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/230*](https://github.com/chaoss/wg-diversity-inclusion/pull/230)
+        > 
+
+  - D\&I Badging 
+    
+      - > Matt looking at D\&I badging for events and projects using our
+        > existing released metrics to walk people through the metrics
+        > to see if they meet the requirements. All of this is done in
+        > the open, and then the project / event get a badge. 
+    
+      - > We would need to actively promote this to make it work. We
+        > could start with some LF projects or other conferences. Maybe
+        > something like
+        > [*https://devopsdays.org/*](https://devopsdays.org/)
+        > [*https://devopsdays.org/organizing*](https://devopsdays.org/organizing)
+        > to certify some of the individual city events.
+    
+      - > The workflow to get people into the badging process could
+        > include some templates and other information to help them be
+        > more inclusive. 
+    
+      - > Concern is that right now, we only have a few of the D\&I
+        > metrics released, and they aren’t really to most important.
+    
+      - > It probably makes sense to roll this out later. We would
+        > definitely need to re-certify periodically.
+    
+      - > Right now, it might make sense to focus on events & maybe
+        > focus our second release on the event metrics.
+
+  - Issues review and replies
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/*](https://github.com/chaoss/wg-diversity-inclusion/)
+
+  - Tracking Spreadsheet
+    
+      - > [*https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1tAGzUiZ9jdORKCnoDQJkOU8tQsZDCZVjcWqXYOSAFmE/edit#gid=0)
+        > 
+
+<span id="anchor-119"></span>
+
+<span id="anchor-120"></span>October 14, 2019
+
+Agenda:
+
+  - Issues review and replies
+  - Consider is the naming of the "Success Metrics" heading
+  - Open Source Summit Lyon presentations we have
+
+Attendees: Dawn, Matt S., Shuah K.
+
+Video: No one attending had access to record the session.
+
+Notes:
+
+  - Issues review and replies
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/*](https://github.com/chaoss/wg-diversity-inclusion/)
+
+  - Consider is the naming of the "Success Metrics" heading
+    
+      - > Georg suggestion: I'll comment on the "Success Metric" in the
+        > template - maybe we can iterate and discuss on the mailing
+        > list. The term "success metrics" is confusing because we call
+        > the whole page a metric, e.g., "Speaker Diversity". Within the
+        > D\&I WG, we then have multiple ways of measuring this metric
+        > with what we call "success metrics". Multiple metrics inside
+        > of a single metric can seem confusing.
+    
+      - > We have "strategies for collecting data" - which is a list
+        > like "interviews and surveys" - then we have the "success
+        > metrics" that specify how the data is collected through
+        > specific interview and survey questions.
+    
+      - > My proposal is to combine the two sections - we don't need to
+        > duplicate the information and can subsume the questions and
+        > details within the "strategies for collecting data" section.
+
+  - Open Source Summit Lyon presentations we have
+    
+      - > Nicole and Dawn are doing a D\&I presentation.
+    
+      - > Matt has a talk
+
+<span id="anchor-121"></span>October 7, 2019
+
+Attendees: Dawn, Georg, Nicole, Daniel
+
+Video: [*https://youtu.be/vXXu3M4TzRk*](https://youtu.be/vXXu3M4TzRk) 
+
+Notes:
+
+  - Review Action Items:
+    
+      - > **AI Matt S.:** Send out a when is good to the mailing list
+        > (D\&I and chaoss).
+        
+          - Sent today
+    
+      - > **AI Georg:** share selection of best surveys on the mailing
+        > list to allow everyone to prepare for the meeting.
+        
+          - Not done
+    
+      - > **AI Georg**: Send Tony from Google who was at CHAOSSCon an
+        > email about getting a Gsuite account for CHAOSS..
+        
+          - Done. Discussed during monthly call.
+
+  - Next week meeting cancelled because of All Things Open 
+
+  - Go through existing D\&I surveys and synthesize
+    
+      - > [*https://docs.google.com/document/d/1GsGdfr4eqbh\_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit\#*](https://docs.google.com/document/d/1GsGdfr4eqbh_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit#)
+
+  - Lessons Learned
+    
+      - > https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/survey-prototype.md
+    
+      - > https://cwiki.apache.org/confluence/display/COMDEV/ASF+Committer+Diversity+Survey+-+2016
+
+  - Demographic questions (in addition to:
+    [*http://nikkistevens.com/open-demographics/*](http://nikkistevens.com/open-demographics/)).
+    
+    
+      - > Dis/Abillity:
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/disability.md
+    
+      - > Sexual Orientation:
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/sexual-orientation.md
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q47:
+    
+      - > Gender Identity: 
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/gender-identity.md
+          - [*ASF
+            Q4*](https://cwiki.apache.org/confluence/display/COMDEV/ASF+Committer+Diversity+Survey+-+2016)
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q45:
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q46:
+    
+      - > Gender Pronouns:
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/gender-pronouns.md
+            
+    
+      - > Language:
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/language.md
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q48: How well can you read and write in English?
+    
+      - > Race/ethnicity
+        
+          - https://github.com/mozilla/diversity/blob/master/data-metrics/surveys/en/race-ethnicity.md
+          - [*ASF
+            Q6*](https://cwiki.apache.org/confluence/display/COMDEV/ASF+Committer+Diversity+Survey+-+2016)
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q43:Thinking of where you were born, are you a member of an
+            ethnicity or nationality that is a considered a minority in
+            that country?
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q44:Thinking of where you currently live, are you a member
+            of an ethnicity or nationality that is a considered a
+            minority in that country?
+    
+      - > Immigration
+        
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q42: Do you currently live in a country other than the one
+            in which you were born?
+    
+      - > Age
+        
+          - [*ASF
+            Q5*](https://cwiki.apache.org/confluence/display/COMDEV/ASF+Committer+Diversity+Survey+-+2016)
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q49:
+    
+      - > Education
+        
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q50: What is highest level of formal education that you have
+            completed?
+    
+      - > Socio-Economic
+        
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+            Q51: What is the highest level of formal education that
+            either of your parents completed?
+          - 
+    
+      - > PAid contributor or volunteer contributor
+        
+          - [*Kernel Contributor
+            survey:*](https://docs.google.com/forms/d/e/1FAIpQLSdFDwiE_D9MuYs2jpG7RnQ0J6YGQJMExiTKiKXOP1GWW7kEXg/viewform)
+            (Y/N) Were you paid to work on this patch? \*
+          - [*ASF
+            Q3*](https://cwiki.apache.org/confluence/display/COMDEV/ASF+Committer+Diversity+Survey+-+2016):
+            In general, do you contribute to Apache as an individual or
+            as an employee of a company?
+          - [*GitHub
+            survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md):
+            Q36: Do you contribute to open source as part of your
+            professional work? In other words, are you paid for any of
+            your time spent on open source contributions?
+
+  - ASF Q7: How often to you refer to ASF policies, processes or
+    guidelines?
+    
+      - > ASF comment: The objective of this question was to find out if
+        > the documentation around policies and guidelines were being
+        > refered to by committers
+    
+      - > We can put this in our Documentation metric, as a qualifier
+        > for the next question (to know how much weight to give any one
+        > person’s answer on the next question).
+
+  - ASF Q8: When you need to locate information about ASF processes,
+    policies or guidelines, which of the following describes your
+    experience?
+    
+      - > ASF comment: The objective of this question was to find out
+        > how easy it was to locate information about policies,
+        > processes or guidelines
+    
+      - > Good for our metric Documentation.
+
+  - Mozilla Participation guidelines question already in our Code of
+    Conduct at Events metric
+
+  - [*Kernel Contributor
+    survey:*](https://docs.google.com/forms/d/e/1FAIpQLSdFDwiE_D9MuYs2jpG7RnQ0J6YGQJMExiTKiKXOP1GWW7kEXg/viewform)
+    
+    
+      - > Planned continued contribution: Do you plan to submit more
+        > patches in future? \*
+    
+      - > Mentorship metrics:
+        
+          - Did you have a mentor work with you prior to your first
+            submission?
+          - Did you participate in a mentorship program?
+          - Would you be interested in helping another person working on
+            their first submission?
+    
+      - > Onboarding metric: What suggestions do you have for improving
+        > the materials and guidance available to new contributors?
+
+  - [*GitHub
+    Survey*](https://github.com/github/open-source-survey/blob/master/survey-instrument.md)
+    has several good questions about contributors background in open
+    source. Could be valuable for drawing correlations.
+    
+      - > https://github.com/github/open-source-survey/blob/master/survey-instrument.md
+    
+      - > Metric: Diversity of Contributions OR Contributor Path
+        
+          - Q1: People participate in open source in different ways.
+            Which of the following activities do you engage in? 
+            
+              - > The answer options are very general, we may want to
+                > break them out into more details.
+        
+          - Q2: is follow-up to Q1, to break out the contribution types
+    
+      - > Q7: When thinking about whether to **use** open source
+        > software, how important are the following things? AND Q8: When
+        > thinking about whether to **contribute** to an open source
+        > project, how important are the following things?
+        
+          - has several items that are relevant to D\&I
+            
+              - > A code of conduct
+            
+              - > A contributing guide
+            
+              - > Responsive maintainers
+            
+              - > Welcoming community
+    
+      - > Metric: Mentorship
+        
+          - Q22: (y/n) Have you ever *received* any kind of help from
+            other people related to using or contributing to an open
+            source project?
+          - Q23: Thinking of the most recent case where someone helped
+            you, how did you find someone to help you?
+          - Q24: Which best describes your prior relationship with the
+            person who helped you?
+          - Q25: What kind of problem did they help you with?
+          - Q26: Have you ever provided help for another person on an
+            open source project?
+          - Q27: Thinking of the most recent case where you helped
+            someone, how did you come to help this person?
+          - Q28: Which best describes your prior relationship with the
+            person you helped?
+          - Q29: What kind of problem did you help them with?
+    
+      - > Harassment / Inclusiveness of OSS
+        
+          - Q30 -- 35 are good for getting an impression about
+            insclusion experiencen
+
+  - The next survey on the list will be the OpenStack Diversity Surveys.
+
+  - 
+
+<span id="anchor-122"></span>September 30, 2019
+
+Attendees: Dawn F., Georg L. Matt G., Matt S., Shuah K., Daniel I.
+
+Video: [*https://youtu.be/hs5Y-2iaDJo*](https://youtu.be/hs5Y-2iaDJo) 
+
+Notes:
+
+  - AI review
+    
+      - > **AI Georg:** We need to provide Angela with a contact person
+        > to use the data: Matt Germonprez as a representative of a
+        > university
+        
+          - done
+    
+      - > **AI Matt G.:** Set up an IRB proposal at UNO. 
+        
+          - done
+
+  - Revisit the time for meeting
+    
+      - > **AI Matt S.:** Send out a when is good to the mailing list
+        > (D\&I and chaoss).
+        
+          - Mo-Fri, 7am-10am PDT
+
+  - ASF survey
+    
+      - > The hope is to share the ASF survey work under an open license
+        > 
+    
+      - > The survey will be discussed in about two weeks for now. 
+    
+      - > Data collection will start on October 21st, when ApacheCon
+        > Europe starts. Data collection will be for one month.
+    
+      - > After the survey will be interviews for in-depth conversations
+        > about the results and to identify inclusion shortcomings and
+        > ideas for improvements.
+    
+      - > Will the interview process be documented and shared? --
+        > probably, if not we can discuss this in the CHAOSS D\&I WG and
+        > document it here.
+    
+      - > Maybe invite Anita Sarma to one of the CHAOSS D\&I WG meetings
+        > to talk in detail about the survey design, items, and how to
+        > make it reusable.
+    
+      - > Maybe we can have a keynote about the collaboration between
+        > ASF and CHAOSS at CHAOSSconEU’20
+
+  - Collection of D\&I surveys in open source
+    
+      - > [*https://docs.google.com/document/d/1GsGdfr4eqbh\_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit\#*](https://docs.google.com/document/d/1GsGdfr4eqbh_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit#)
+        > 
+    
+      - > What should we do with this data?
+    
+      - > Maintaining lists on the internet is a lot of work and
+        > difficult.
+    
+      - > Maybe identify well-worded questions and include them in the
+        > CHAOSS D\&I metrics. Create a synthesis of the questions.
+    
+      - > AI next week: go through the surveys. 
+    
+      - > **AI Georg:** share selection of best surveys on the mailing
+        > list to allow everyone to prepare for the meeting.
+
+  - Persistence of CHAOSS work?
+    
+      - > Daniel shared an experience where google docs disappeared
+        > because the owner’s GSuite account was closed. 
+    
+      - > Does Google sponsor open source projects and provide free
+        > GSuite accounts?
+    
+      - > **AI Georg**: Send Tony from Google who was at CHAOSSCon an
+        > email about getting a Gsuite account for CHAOSS..
+
+  - Metrics Template for all CHAOSS WGs
+    
+      - > At the last CHAOSS community call, we started work on unifying
+        > the template for all working groups.
+    
+      - > The new template should make metric representations across
+        > working groups and across CHAOSS look and feel similar and
+        > familiar.
+    
+      - > We will have to update the released metrics and apply the new
+        > template to all new metrics
+    
+      - > This is still work in progress.
+    
+      - > Template as it was discussed during the community call.
+        
+          - **Description (required)**
+        
+          - **Objectives (required)**
+        
+          - **Implementation (required)**
+            
+              - > ~~Filters (optional)~~
+            
+              - > ~~Visualizations (optional)~~
+            
+              - > ~~Tools providing metric (was: Known implementations)
+                > (optional)~~
+            
+              - > Data Collection Strategies (optional)
+                
+                  - *D\&I WG: Strategies*
+                    
+                      - > *Interviews*
+                    
+                      - > *Surveys*
+                    
+                      - > *...*
+            
+              - >  Success Metrics (optional)
+                
+                  - *D\&I WG: Success Metrics*
+        
+          - **Resources (required)**
+
+  - We revised the Onboarding metric based on the feedback and input we
+    had from the CHAOSScon Workshop. 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+
+<span id="anchor-123"></span>September 23, 2019
+
+Attendees: Dawn F, Matt S., Matt G., Georg L., Daniel I., Nicole H.
+
+Video: [*https://youtu.be/MAoUUmgGcak*](https://youtu.be/MAoUUmgGcak) 
+
+Notes:
+
+  - Meeting with LF Events. See a summary and next steps on the mailing
+    list.
+    
+      - > We need to be very careful with the data.
+    
+      - > Not everyone in D\&I will see the data.
+        
+          - **AI Georg:** We need to provide Angela with a contact
+            person to use the data: Matt Germonprez as a representative
+            of a university
+        
+          - **AI Matt G.:** Set up an IRB proposal at UNO. 
+        
+          - External people to be on the IRB:
+            
+              - > Georg L.
+    
+      - > Maybe ask the LF Event team to brand the CHAOSS metrics.
+        
+          - Individual questions? -- no
+          - At start of survey? -- better :D
+          - **Maybe: **Some questions are developed from the CHAOSS
+            project -- a Linux Foundation project that develops
+            standardized metrics to measure open source project health.
+            Learn more at
+            [*https://chaoss.community*](https://chaoss.community)
+
+  - Collecting D\&I surveys in Open Source.
+    
+      - > Georg reached out to other communities and on Twitter. Still
+        > need to put feedback in.
+    
+      - > Will be used as input to the ASF D\&I survey that Apache is
+        > looking to do with Bitergia’s help. Daniel Izquierdo and Anita
+        > Sarma will work on this.
+    
+      - > The difference between the OpenStack work and the ASF work is
+        > that the former was more quantitative and the latter will be
+        > more qualitative.
+    
+      - > Join the dev@diversity.apache.org mailing list to stay up to
+        > date
+
+  - Nicole is working on a comprehensive blog post or multiple posts
+    about CHAOSSCon. Transcribing recordings right now.
+
+  - Matt’s LWN.net talk was posted -- highlighting D\&I work
+    
+      - > [*https://lwn.net/Articles/798066/*](https://lwn.net/Articles/798066/)
+        > 
+
+  - We revised the Onboarding metric based on the feedback and input we
+    had from the CHAOSScon Workshop. 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+
+<span id="anchor-124"></span>September 16, 2019
+
+Attendees: Dawn F., Matt S., Kevin L., Georg L.
+
+Video: [*https://youtu.be/WYUR3drSC-A*](https://youtu.be/WYUR3drSC-A) 
+
+Notes: 
+
+  - We are meeting with Angela Brown from LF Events on Wednesday 11am
+    CT. Everyone is welcome. We will use our regular CHAOSS Zoom channel
+    for the meeting.
+
+  - Collecting D\&I surveys in Open Source.
+    
+      - > Started a document:
+        > [*https://docs.google.com/document/d/1GsGdfr4eqbh\_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit\#*](https://docs.google.com/document/d/1GsGdfr4eqbh_bWTH5oYbQcko6OGAlmQCo8-BqybEFoo/edit#)
+    
+      - > Issue for tracking progress:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/220*](https://github.com/chaoss/wg-diversity-inclusion/issues/220)
+    
+      - > Added Apache survey
+    
+      - > Added OpenStack Gender report
+    
+      - > AI Georg: Share with other groups
+        
+          - dev@diversity.apache.org
+          - Opensourcediversity.org forum
+          - Emma’s mailing list
+          - SustainOSS forum
+
+  - We revised the Onboarding metric based on the feedback and input we
+    had from the CHAOSScon Workshop. 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+
+<span id="anchor-125"></span>September 9, 2019
+
+Attendees: Matt G, Matt S, Dawn F, Georg L, Kevin L, Nicole H
+
+Video: [*https://youtu.be/6WqqyILZ9JQ*](https://youtu.be/6WqqyILZ9JQ) 
+
+Notes:
+
+  - Idea to do a D\&I report for one open source project.
+    
+      - > Maybe do it for a CNCF project, they have gender information.
+    
+      - > Maybe do Zephyr where we have good connections through Kate.
+    
+      - > The goal is to be proactive.
+
+  - Angela from LF is willing to meet with us to go through the D\&I
+    metrics for events and start collecting them
+    
+      - > **AI Georg:** Send doodle to list and Angela for scheduling
+        > that meeting.
+
+  - Collect D\&I survey instruments that have been used in recent years.
+    
+      - > Get an overview of survey items that have been used, that can
+        > be reused 
+    
+      - > To have a better understanding of D\&I related issues for ASF
+        > projects
+    
+      - > **AI Georg:** share a google doc for collecting instruments.
+    
+      - > [*https://www.linuxfoundation.org/tag/survey/*](https://www.linuxfoundation.org/tag/survey/)
+        >  
+    
+      - > **AI Matt G:** Explore who, at the LF, might be able to run a
+        > survey (or is working on a D\&I survey - Sarah had been
+        > mentioned this)
+
+  - The TODO group D\&I guidelines are still work in progress.
+
+  - Nicole is working on a comprehensive blog about CHAOSSCon. Draft
+    should be ready this week. Will share for feedback.
+    
+      - > [*https://www.rev.com/automated-transcription-1*](https://www.rev.com/automated-transcription-1)
+
+  - We revised the Onboarding metric based on the feedback and input we
+    had from the CHAOSScon Workshop. 
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+
+<span id="anchor-126"></span>August 26, 2019
+
+Attendees: Georg Link, Matt Snell, Kevin Lumbard, Shuah Khan 
+
+Notes:
+
+  - Review of CHAOSScon/OSSNA
+    
+      - > The **CHAOSScon workshop** (Nicole H., Dawn F., Georg L.) was
+        > a full success, we had 3 tables with good engagement advancing
+        > the metrics: sponsorship, onboarding, and documentation.
+    
+      - > The **OSSNA D\&I report tutorial** (Georg L., Nicole H.) had a
+        > small audience but good discussion afterwards, especially
+        > around how to deal with resistance.
+    
+      - > The **OSSNA basic CHAOSS introduction session** (Matt G.) had
+        > a lot of discussion about D\&I metrics.
+    
+      - > **AI Georg**: add contributors to readme on repo.
+
+  - Gris Cuevas from ASF had a lightning talk at CHAOSScon about the ASF
+    D\&I Initiative. A D\&I survey will be conducted this year to
+    measure the status quo at ASF. Interest in advancing D\&I survey
+    questions was also voiced throughout OSSNA by different people. We
+    may invite everyone to discuss survey design and review our
+    metrics.?
+    
+      - > Shuah shared a thank you email and survey she sends to new
+        > Kernel contributors:
+        > [*https://drive.google.com/file/d/1ih17JAQzwWDqr53FK698tCJYqIytg1q7/view?usp=sharing*](https://drive.google.com/file/d/1ih17JAQzwWDqr53FK698tCJYqIytg1q7/view?usp=sharing)
+    
+      - > [*https://forms.gle/WPXXpebWJaCz8gTi8*](https://forms.gle/WPXXpebWJaCz8gTi8)
+    
+      - > New contributors are identified using the CHAOSS Cregit tool.
+    
+      - > Q: “Any suggestions on how we can improve the materials and
+        > guidance available to new contributors?” - short answer
+        
+          - Suggestion: “What suggestions do you have for improving the
+            materials and guidance available to new contributors?” -
+            long answer question
+    
+      - > Q: “Would you like to be contacted to discuss your experiences
+        > further?”
+        
+          - The goal of the question is to see if they would be willing
+            to discuss their experience further.
+          - Clarify the expectations for what will happen if answer
+            “yes” is chosen.
+    
+      - > **AI Georg:** ask for more survey from other
+        > projects/foundations.
+
+  - Angela Brown from LF is very interested in applying D\&I metrics for
+    events. 
+    
+      - > **AI Georg:** Schedule a meeting with Angela and D\&I WG
+        > members for reviewing our metrics, developing a data
+        > collection strategy, and next steps
+
+  - **AI Matt:** send notes to D\&I mailing list.
+
+  - **AI Georg:** Friday, Georg will send a reminder to the D\&I mailing
+    list.
+
+<span id="anchor-127"></span>August 19, 2019
+
+No meeting because of CHAOSScon and OSSNA travel
+
+<span id="anchor-128"></span>August 12, 2019
+
+Attendees: Matt Germonprez, Daniel Izquierdo, Shuah Khan
+
+Agenda/Notes: 
+
+  - TODO Group editing
+    
+      - > Settling on term for ‘open source’ 
+        
+          - Open Source 
+          - Open Source Project 
+          - **Open Source Community **
+          - Open Source Ecosystem 
+
+  - Linux Kernel Mentorship 
+    
+      - > Wrapped up fall selection process. Summer session is in
+        > progress. 
+    
+      - > Two have been selected 
+    
+      - > Pool of selected applicants
+        
+          - Women: 2
+          - Men: 2
+          - Professional advancement: 2
+          - College students: 2
+          - Geographical diversity: 2
+          - Underrepresented groups in the technology and open source
+            communities: 4
+    
+      - > Paired with mentors in the community 
+    
+      - > 
+
+<span id="anchor-129"></span>August 5, 2019
+
+Attendees: Georg Link, Matt Germonprez, Daniel Izquierdo, Kevin Lumbard,
+Dawn Foster
+
+Video:[*https://youtu.be/FZl0DIJbLZU*](https://youtu.be/FZl0DIJbLZU) 
+
+Agenda/Notes:
+
+  - Getting the release issues resolved:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22Metrics+Candidate+Release%22*](https://github.com/chaoss/wg-diversity-inclusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22Metrics+Candidate+Release%22)
+
+  - 
+
+  - Postponed
+    
+      - > Discussion on new additions to the mentorship use case based
+        > on Shuah comments.
+    
+      - > Discussion on new additions to the communication inclusivity
+        > based on Shuah comments.
+    
+      - > Metrics Release candidate. Those with the ‘metrics candidate
+        > release’ label at
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+        > . 
+
+<span id="anchor-130"></span>July 29, 2019
+
+Attendees: Shuah, Daniel, Matt
+
+Video: didn’t have record capabilities
+
+Agenda/Notes:
+
+  - CHAOSSCON meeting
+
+  - Shuah talk on D\&I at OSS. 
+    
+      - > [*https://ossalsjp19.sched.com/event/QLxN/keynote-making-connections-new-developers-the-linux-kernel-community-shuah-khan-fellow-the-linux-foundation*](https://ossalsjp19.sched.com/event/QLxN/keynote-making-connections-new-developers-the-linux-kernel-community-shuah-khan-fellow-the-linux-foundation)
+
+  - Discussion on Mentorship metric
+
+  - Discussion on Communication Inclusivity metric.
+
+Discussion about how to start conversations, how to start a community.
+And how to bring new people just starting out of college or changing
+careers. How can we help them to be part of the community to create a
+community? 
+
+  - There might be issues such as language barriers, engaging into
+    discussion, effective communication.
+
+Other aspects of diversity are important as well.
+
+Potential input from Shuah: progress Shuah is doing, experiences and
+share specific knowledge and expertise in the area.
+
+**Notes on metrics**:
+
+https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/leadership/mentorship.md
+
+**How to gather information in the mentorship**.
+
+Shuah is asking her students about the community:
+
+\* how useful was the community?
+
+\* were people useful for you? 
+
+\* was the community welcoming
+
+She's been collecting quotes after the initial selection after 6 weeks
+and then after each of the three evaluation processes during the 12 week
+program.
+
+Educating and mentoring new developers. Staying patient while educating
+and answering the same questions more than once. Developing FAQ
+(Frequently Answered Questions).
+
+\* This is going to be shared in her talk at the OSS Summit San Diego.
+
+Track new contributors for each single release (each three months)
+
+\* Tracking new developers that are women.
+
+\* Did they have any help? Have they been through any mentorship
+program? Do they want to mentor? 
+
+\* They want to watch over time the retention angle. Continue
+contributing to open source. Do they have an interest in keep
+contributing?
+
+\* This depends on the company although this depends.
+
+Track existing documents? How can we keep track what Shuah is doing so
+far?
+
+**Communication Inclusivity**.
+
+How to teach English speakers not to use jargon.
+
+This is a big umbrella for effective communication in general. 
+
+If I use jargon, newcomers may not feel comfortable asking for this
+meaning in a public channel. Having a specific safe environment where
+people can ask freely their specific questions about jargon meaning or
+any other type of questions.
+
+Implicit words vs explicit, way of working with the community. Avoid
+subjective talks, humor, etc. This is not understood by newcomers.
+
+It’s about empowering people asking questions freely in any channel so
+they feel comfortable.
+
+This jargon or tech. Vocabulary does not need to be ‘bad’ or ‘good’ by
+itself, but this is a learning path. This is like moving to a new place
+where you have to learn where things and places are. And how to bring
+your own uniqueness to the place.
+
+<span id="anchor-131"></span>July 22, 2019
+
+Attendees: Nicole, Matt, Daniel
+
+Notes: Discussion on having specific badges for projects following good
+practices from D\&I. The example we were discussing about is the [*CII
+Badge
+Program*](https://www.coreinfrastructure.org/programs/badge-program/)
+
+<span id="anchor-132"></span>July 8, 2019
+
+Attendees: Dawn, Nicole, Matt, Daniel
+
+Video: Didn’t have record capabilities :( 
+
+Agenda/Notes: 
+
+  - Overview of the CHAOSScon D\&I session 
+    
+      - > Working towards the development of new metrics 
+
+  - Looking to develop the D\&I team
+
+  - Connect with people directly to include them in the meetings 
+
+  - AI: Matt figure out who at the LF is doing D\&I work
+
+  - AI: Nicole to reach back out to Hyperledger folks to find out what
+    is going on with the Indy project
+
+  - Working to advance the OSSNA D\&I session (Nicole and Georg)
+
+  - Do we want to make a concerted effort to deploy D\&I Metrics? 
+    
+      - > Community manager summit (July 14th)
+    
+      - > Nicole could attend and present D\&I work 
+        
+          - Daniel will confirm 
+          - Talk potential: Usage and application of the metrics --
+            Identify or demonstrate pilot projects 
+          - How can the metrics have an impact? 
+    
+      - > Can we connect with the TODO group regarding their D\&I guide?
+        > 
+    
+      - > We have wins that we need to be conscious of and continue to
+        > document: 
+        
+          - Mozilla and their use of CHAOSS work to inform their
+            internal D\&I checklist:
+            [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/governance-basic.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/governance-basic.md)
+        
+          - OpenStack and their OpenStack gender report:
+            [*https://superuser.openstack.org/articles/2018-gender-diversity-report/*](https://superuser.openstack.org/articles/2018-gender-diversity-report/)
+        
+          - While these may not be direct 1-to-1 correlation of the
+            CHAOSS metrics being deployed within a project, they
+            demonstrate the impact that the CHAOSS D\&I workgroup is
+            having in a short period of time
+        
+          - Other potential points of connection include: 
+            
+              - > The TODO Group 
+            
+              - > Hyperledger
+            
+              - > Yet to be determined pilot projects? 
+            
+              - > I swear there was another but I’ve already forgotten 
+
+  - NO MEETING NEXT WEEK DUE TO OSCON
+
+<span id="anchor-133"></span>July 1, 2019
+
+Cancelling due to lack of participation in the July 4th holiday week :) 
+
+<span id="anchor-134"></span>June 24, 2019
+
+Video:[*https://youtu.be/rA7vlg4HHB0*](https://youtu.be/rA7vlg4HHB0) 
+
+Agenda/Notes: 
+
+  - Release of metrics & promotion plan
+    
+      - > Promote, Georg is talking to Berry from the Sustain Our
+        > Software podcast
+        
+          - Before CHAOSScon, after release
+    
+      - > Promote, on twitter
+    
+      - > Working groups are almost ready
+        
+          - Announce internally on weekly call tomorrow
+          - Then announce the comment period to the mailing list and
+            twitter (1 month comment period -- official release in
+            August)
+    
+      - > Someone in the working group needs to watch the issues for
+        > comments
+
+  - How to deal with feedback on comments:
+    
+      - > It would be nice if the working group members could do any
+        > changes and make the experience for anyone commenting as
+        > pleasant as possible.
+
+  - Open Source Summit Europe CFP is coming up **JULY 1st**.
+    
+      - > Who is going and can submit something.
+    
+      - > **AI Nicole:** Send email to D\&I list with a google doc
+        > linked to it to prepare a submission.
+    
+      - > Maybe reuse the same we had for OSSNA:
+        > [*https://docs.google.com/document/d/14CSYIc\_5OHNERQzoHALHsHplPW\_DjKNlCo87dmxH1OE/edit*](https://docs.google.com/document/d/14CSYIc_5OHNERQzoHALHsHplPW_DjKNlCo87dmxH1OE/edit)
+        > 
+
+  - OpenInfrastructure Summit (was OpenStack Summit) JULY 2nd
+
+  - KubeCon North America JULY 12th
+
+<span id="anchor-135"></span>June 17, 2019
+
+No video.
+
+Notes: 
+
+  - Release tracking document
+    [*https://docs.google.com/spreadsheets/d/1\_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit#gid=0)
+
+  - Governance: Code of Conduct.
+    
+      - > Working document:
+        > [*https://docs.google.com/document/d/1DGiBT3lUaIcNJBsDICsliJPNumOglzFPGJKnWiU3pD0/edit\#heading=h.u47zv5hlteaq*](https://docs.google.com/document/d/1DGiBT3lUaIcNJBsDICsliJPNumOglzFPGJKnWiU3pD0/edit#heading=h.u47zv5hlteaq)
+
+  - Pull request:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pull/182*](https://github.com/chaoss/wg-diversity-inclusion/pull/182)
+
+Topics to talk about after finishing metric:
+
+  - OSCON Birds of a feather?
+
+  - CLSx session?
+
+  - CHAOSScon - need to prep our tutorial. [*Slides from the EU
+    version*](https://docs.google.com/presentation/d/1969aex0VZNeCcnTztYCFxG7Q98JnHV5IGtylh59a-H0/edit).
+    [*Description on
+    website*](https://chaoss.community/chaosscon-2019-eu).
+    
+      - > New slides for CHAOSSconNA19:
+        > [*https://docs.google.com/presentation/d/1Oei7cvkndXk06Lr5q\_0kZUlynJ\_GsBBuf9eWl-Ob5rg/edit*](https://docs.google.com/presentation/d/1Oei7cvkndXk06Lr5q_0kZUlynJ_GsBBuf9eWl-Ob5rg/edit)
+    
+      - > TODO shortly before we have the session:
+        
+          - Choose metrics
+          - Prepare google docs
+          - Write question and description
+          - Let people focus on the rest
+    
+      - > Better job this time: volunteers from D\&I group to sit with
+        > the breakout sessions.
+
+<span id="anchor-136"></span>June 10, 2019
+
+Video: [*https://youtu.be/6KskZxALShA*](https://youtu.be/6KskZxALShA) 
+
+Agenda:
+
+  - Work on metrics
+
+Notes:
+
+  - > Attendees: Georg Link, Matt Germonprez, Daniel Izquerdo, Ell
+    > Marquez
+
+  - > Pull requests from last week’s meeting:
+    > [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    > (pr
+    > [*177*](https://github.com/chaoss/wg-diversity-inclusion/pull/177),
+    > [*178*](https://github.com/chaoss/wg-diversity-inclusion/pull/178),
+    > [*179*](https://github.com/chaoss/wg-diversity-inclusion/pull/179),
+    > [*180*](https://github.com/chaoss/wg-diversity-inclusion/pull/180))
+    
+      - removed "Sample" from headings - per Emma’s comment.
+      - merged
+
+  - > AI: Matt connect with Kevin to consider how to display metrics on
+    > the web page. Suggestion is to use the four identified metrics
+    > from D\&I as a way to think though display. 
+    
+      - Done
+
+  - > Suggestion that for any metric that has a known implementation,
+    > the metrics detail page includes a new section called **Known
+    > Implementations **just before the **References **section.
+
+  - > Release tracking document
+    > [*https://docs.google.com/spreadsheets/d/1\_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit#gid=0)
+
+  - > Governance: Code of Conduct
+
+  - > Working document:
+    > [*https://docs.google.com/document/d/1DGiBT3lUaIcNJBsDICsliJPNumOglzFPGJKnWiU3pD0/edit\#v*](https://docs.google.com/document/d/1DGiBT3lUaIcNJBsDICsliJPNumOglzFPGJKnWiU3pD0/edit#v)
+    
+      - QUESTIONS at other metrics:
+      - **Question:** How does enabling families to attend together
+        support diversity and inclusion of the event?
+      - **Question:** How does the Code of Conduct for events support
+        diversity and inclusion?
+      - **Question:** How are Diversity Access Tickets used to support
+        diversity and inclusion for an event?
+
+<span id="anchor-137"></span>June 3, 2019
+
+Video: [*https://youtu.be/\_elah0w4ofA*](https://youtu.be/_elah0w4ofA) 
+
+Notes:
+
+  - Attendees: Dawn, Daniel, Ry, Vladimir, Georg
+
+  - Draft and submit CHAOSScon workshop or 20min facilitated session
+    
+      - > Same workshop as in Brussels?
+    
+      - > AI Georg: Submit the same text as CHAOSScon EU ‘19 - Dawn
+        > Foster and Georg Link as facilitators.
+
+  - Hackathon - metrics release
+    
+      - > Release tracking document
+        > [*https://docs.google.com/spreadsheets/d/1\_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit#gid=0)
+    
+      - > Release checklist: 
+        
+          - [*https://github.com/chaoss/metrics/blob/master/RELEASING.md*](https://github.com/chaoss/metrics/blob/master/RELEASING.md)
+
+  - Diversity Access Tickets
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/diversity-tickets.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/diversity-tickets.md)
+    
+      - > Editable version:
+        > [*https://docs.google.com/document/d/1Gs1xm\_-ojc6Y32pYmtdbROnMa81ux\_RiK8aeXU43QtE/edit\#*](https://docs.google.com/document/d/1Gs1xm_-ojc6Y32pYmtdbROnMa81ux_RiK8aeXU43QtE/edit#)
+    
+      - > **AI Georg:** create pull request
+
+  - Code of Conduct at Events
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/event-code-of-conduct.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/event-code-of-conduct.md)
+    
+      - > Editable version
+        > [*https://docs.google.com/document/d/1XKrsbVCPA5dqEfOnMVRyRcjqRNS05icKLojdgQawph0/edit\#*](https://docs.google.com/document/d/1XKrsbVCPA5dqEfOnMVRyRcjqRNS05icKLojdgQawph0/edit#)
+    
+      - > **AI Georg:** Pull request 
+
+  - Family Friendliness
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/family-friendly.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/events/family-friendly.md)
+    
+      - > Editable version  
+        > [*https://docs.google.com/document/d/1jiylWjkLm04paBcflkNn0-yahvy958ShiUbrKrG20Zs/edit*](https://docs.google.com/document/d/1jiylWjkLm04paBcflkNn0-yahvy958ShiUbrKrG20Zs/edit)
+
+  - Leadership: Mentorship
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/leadership/mentorship.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/leadership/mentorship.md)
+        > 
+    
+      - > Editable document
+        > [*https://docs.google.com/document/d/1pQnnbkDrVbZK\_sJ8Nl84ijwxfHSmUNMwIDe5dVJ2pf4/edit*](https://docs.google.com/document/d/1pQnnbkDrVbZK_sJ8Nl84ijwxfHSmUNMwIDe5dVJ2pf4/edit)
+    
+      - > **AI Georg:** Pull request 
+    
+      - > 
+
+<span id="anchor-138"></span>MAY 27, 2019
+
+Video: [*https://youtu.be/8y\_wBFoCMSA*](https://youtu.be/8y_wBFoCMSA) 
+
+Note: 
+
+  - KubeCon - 25-30 people at the panel. Covered historical details to
+    chaoss. Discussed experience with building communities.
+    
+      - > Panelists: Dawn Foster, Jonas Rosland, Nicole Huesman,
+        > Guinevere Saenger, Daniel Izquierdo, 
+
+  - Attendee question: How to have an inclusive event in spite of
+    regional culture? Organizer received rejections for inviting diverse
+    speakers. 
+    
+      - > For people who are new to your country. Maybe provide a
+        > translator to bridge any language barrier.
+    
+      - > Security; Help with transfers from airport. Offer group
+        > outings.
+    
+      - > (Maybe add a CHAOSS metric around event safety)
+
+  - Last week was InnerSource Spain meeting. Several CHAOSS members also
+    talked about CHAOSS there.
+
+  - We need to start focusing on releasing metrics. Review and accept
+    metrics for release.
+
+  - Organize a hackathon to polish existing metrics or produce new
+    metrics (perhaps send some details to the mailing list to welcome
+    everyone to join this).
+    
+      - > AI Georg will send an email to invite people.
+
+<span id="anchor-139"></span>May 20, 2019
+
+May 20 meeting cancelled because of KubeCon
+
+<span id="anchor-140"></span>May 13, 2019
+
+Video: [*https://youtu.be/PSwGrlCGi1o*](https://youtu.be/PSwGrlCGi1o) 
+
+  - Attendees: Dawn Foster, Daniel Izquierdo, Georg Link, Matt
+    Germonprez
+
+  - InnerSource Spain: Tuesday, May 21, 2019, 3:00 PM to 6:00 PM
+    
+      - > If anyone is attending KubeCon and has an interest in inner
+        > source is invited.
+    
+      - > https://www.meetup.com/InnerSource-Spain/events/260507248/
+
+  - KubeCon - finding a Kubernetes member to be on the panel
+    
+      - > If we don’t find anyone else, Dawn could step up
+
+  - Community Bridge
+    
+      - > LF transferred unexpectedly $16,000
+
+  - CHAOSScon prospectus
+    
+      - > Matt will send out soon
+
+  - Grace Hopper
+    
+      - > Matt meets with Zarah soon
+    
+      - > We need to determine who may be going soon
+    
+      - > No need to have all women mentors
+    
+      - > Daniel will reach out Matt about someone from GrimoireLab
+
+  - The New Stack podcast was released with Nicole and Georg talking
+    about the D\&I 
+    
+      - > [*https://thenewstack.io/how-chaoss-measures-diversity-windows-gets-a-proper-terminal/*](https://thenewstack.io/how-chaoss-measures-diversity-windows-gets-a-proper-terminal/)
+    
+      - > Georg asking for feedback if possible and better ways to
+        > communicate CHAOSS mission.
+
+  - Working session on a metrics
+    
+      - > Reviewed our level of completeness exercise
+        > ([*\#174*](https://github.com/chaoss/wg-diversity-inclusion/issues/174))
+        > to see where we needed work done and decided to focus on
+        > Contribution Types metric ([*issue
+        > \#116*](https://github.com/chaoss/wg-diversity-inclusion/issues/116))
+    
+      - > Reviewed [*pull request
+        > \#153*](https://github.com/chaoss/wg-diversity-inclusion/pull/153)
+        > and Emma’s feedback.
+    
+      - > Work on metric in ([*issue
+        > \#116*](https://github.com/chaoss/wg-diversity-inclusion/issues/116)):
+        > [*https://docs.google.com/document/d/1FJNsWimNN4KUgtCeq6z3etY\_x3KJOrA376gCtOCIkzg/edit*](https://docs.google.com/document/d/1FJNsWimNN4KUgtCeq6z3etY_x3KJOrA376gCtOCIkzg/edit)
+        > 
+    
+      - > Next step:
+        
+          - **AI Georg:** Break out metric into its components: Common
+            Metric, Contributor Community Diversity, and Recognition of
+            Good Work
+    
+      - > Right now, we have too much in here and are juggling too many
+        > parts
+        
+          - Component 1 (**Common Metric**): How to obtain contribution
+            types and which contribution types exist is a universal
+            problem that can live in the Common Metrics WG. Other WGs
+            may have different angles on it and ask for example "How
+            active is the community across contribution types"
+          - Component 2 (**Recognition of Good Work**): We have
+            contribution types in the focus area Recognition of Good
+            Work and should create a document that tailors the metric
+            specifically to recognition.
+          - Component 3 (**Contributor Community Diversity**): We also
+            have contribution types in the focus area Contributor
+            Community Diversity and should create a document that
+            tailors the metric specifically to understanding the
+            diversity of our community members across contribution types
+
+  - Cancel meeting next week May 20, due to KubeCon
+    
+      - > Next meeting is May 27
+
+<span id="anchor-141"></span>May 6, 2019
+
+  - Attendees: Matt Germonprez, Daniel Izquierdo, Nicole Huesman, Kevin
+    Lumbard
+
+  - KubeCon 
+    
+      - > Working to finalize the submission with respect speakers and
+        > structure 
+    
+      - > Working to find someone from the Kubernetes community 
+    
+      - > May 23rd, 2019 
+    
+      - > [*https://kccnceu19.sched.com/event/MPZe/panel-discussion-metrics-that-matter-how-to-forge-more-diverse-inclusive-communities-sarah-conway-linux-foundation-daniel-izquierdo-bitergia-and-nicole-huesman*](https://kccnceu19.sched.com/event/MPZe/panel-discussion-metrics-that-matter-how-to-forge-more-diverse-inclusive-communities-sarah-conway-linux-foundation-daniel-izquierdo-bitergia-and-nicole-huesman)
+
+  - InnerSource Commons
+    
+      - > [*https://www.meetup.com/InnerSource-Spain/events/260507248*](https://www.meetup.com/InnerSource-Spain/events/260507248)
+        > 
+
+  - Grace Hopper 
+    
+      - > Tue, Oct 1, 2019 – Fri, Oct 4, 2019 
+
+  - Community Bridge
+    
+      - > [*https://funding.communitybridge.org/projects/a4a43b66-f707-47b4-97cc-484285c274a8*](https://funding.communitybridge.org/projects/a4a43b66-f707-47b4-97cc-484285c274a8)
+        > 
+
+  - 
+
+  - 
+
+<span id="anchor-142"></span>April 29, 2019
+
+Agenda:
+
+  - Review Action Items
+  - CHAOSSCon planning meeting being scheduled 
+  - Emma’s D\&I in OSS mailing list is discussing to start a D\&I book
+    club
+  - LF Diversity, Sustainability, and Inclusion (DSI) is planning to
+    develop a DSI survey for projects
+  - The New Stack article update
+  - Next week’s volunteers for facilitation and notes
+
+Video: [*https://youtu.be/SdCfVK\_X75s*](https://youtu.be/SdCfVK_X75s) 
+
+Notes:
+
+  - Attendees: Sean Goggins, Georg Link, Sarah Conway
+
+  - Review Action Items
+    
+      - > **AI Sarah:** Talk to Paris about KubeCon session.
+        
+          - Delayed
+    
+      - > **AI Nicole:** Talk to Jaice about KubeCon session.
+        
+          - No update
+    
+      - > **AI Georg:** move the content from Emma’s proposal to a
+        > google doc and continue conversation on mailing list.
+        
+          - open
+    
+      - > **AI Nicole and Georg: **Write blog post on the
+        > Goal-Question-Metric approach. 
+        
+          - No update
+    
+      - > **AI Sarah:** take a look at Matt’s email about information
+        > needed for Community  
+        > Bridge. 
+        
+          - Done. In-progress with Matt - waiting on Community Bridge to
+            resolve an issue with our chaoss.community top level domain.
+    
+      - > **AI Matt:** Take ideas/information from Daniel and Sean and
+        > fill out Grace Hopper Event Google form.
+        
+          - No update
+    
+      - > **AI Georg: **identify sources for statistics in opening
+        > description to Sponsoring Metric
+        
+          - Postponed to this week
+    
+      - > **AI All:** Research Sponsoring Metric further, including work
+        > of Yulkendy. 
+        
+          - Postponed to this week
+    
+      - > **AI Georg: **send email to mailing list to research
+        > Sponsoring Metric further for next week’s.
+        
+          - Postponed to this week
+
+  - CHAOSSCon planning meeting being scheduled 
+    
+      - > Get on agenda for Open Source Summit with registration form
+    
+      - > Promote CFP, sponsorship opportunity 
+
+  - Emma’s D\&I in OSS mailing list is discussing to start a D\&I book
+    club
+    
+      - > Share short videos or books for easy digestion
+    
+      - > Idea is well received
+
+  - LF Diversity, Sustainability, and Inclusion (DSI)
+    
+      - > Planning to develop a standard set of survey questions.
+    
+      - > Use OpenStack survey as examples.
+    
+      - > LF kicks off the survey development. 
+    
+      - > Check and refine with the D\&I Working Group.
+
+  - The New Stack
+    
+      - > Should be published early this week.
+    
+      - > They will get in touch for scheduling podcast.
+
+  - Next week’s volunteers for facilitation and notes
+    
+      - > **AI Georg** will send out reminder, but cannot attend.
+
+<span id="anchor-143"></span>April 22, 2019
+
+Agenda:
+
+  - Review Action items
+  - The New Stack
+  - Grace Hopper 
+  - Sponsoring Metric
+  - Next week’s facilitator and notetaker
+
+Video: [*https://youtu.be/q4HolyB8Qj0*](https://youtu.be/q4HolyB8Qj0) 
+
+Notes:
+
+  - Attendees: Sarah Conway, Georg Link, Daniel Izquierdo, Sean Goggins,
+    Polaris000, Matt Germonprez, Nicole Huesman.
+
+  - Review Action items
+    
+      - > **AI Sarah:** Talk to Paris about KubeCon session.
+        
+          - Call this week
+    
+      - > **AI Nicole:** Talk to Jaice about KubeCon session.
+        
+          - No update
+    
+      - > **AI Daniel:** Talk to Silona about KubeCon session 
+        
+          - Silona is not attending KubeCon this time
+          - **(new) AI Sarah:** Schedule call for talk at KubeCon
+            Barcelona with panelist, avoid May 1-2
+    
+      - > **AI Georg:** move the content from Emma’s proposal to a
+        > google doc and continue conversation on mailing list.
+        
+          - Open
+    
+      - > **AI Nicole and Georg: **Write blog post on the
+        > Goal-Question-Metric approach. 
+        
+          - Working on the post, will touch base this week to move
+            forward 
+    
+      - > **AI Sarah:** Send out a good first issue email on mailing
+        > list.
+        
+          - Done
+    
+      - > **AI Sarah:** take a look at Matt’s email about information
+        > needed for Community  
+        > Bridge. 
+        
+          - [*https://docs.google.com/document/d/1Ka7-2YmJWT3DQrRRR0HbzCHqSVEH-Yz3S-DuUNgaDv8/edit\#*](https://docs.google.com/document/d/1Ka7-2YmJWT3DQrRRR0HbzCHqSVEH-Yz3S-DuUNgaDv8/edit#)
+            
+          - Sarah started filling out the CB form, Matt and Georg agreed
+            to serve as mentors; target spring or fall mentorships
+          - **AI Matt:** submit CommunityBridge application.
+          - Move GSoC money over to CommunityBridge at the same time. 
+          - **AI Matt:** Matt working with LF to move money over to
+            CommunityBridge. 
+          - Google Season of Docs: Matt submitted official application
+            on behalf of CHAOSS
+          - **AI Georg:** Reach out to Langdon and Manny to see where
+            the BU Spark mentorship is at. Summer program. 
+    
+      - > **AI Georg:** Send Level of Completeness exercise results a
+    
+      - > nd thoughts on releasing metrics to general CHAOSS email list
+        > to get feedback from other WGs and lazy consensus on this
+        > decision. 
+        
+          - [*https://docs.google.com/spreadsheets/d/1\_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit?usp=sharing*](https://docs.google.com/spreadsheets/d/1_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit?usp=sharing)
+            
+          - D\&I completed the spreadsheet, received positive feedback
+            from other WGs. Other WGs will take D\&I spreadsheet and add
+            tabs for their WGs. 
+    
+      - > **AI All:** Please read and provide feedback on the [*“Past
+        > and Present” blog
+        > post*](https://docs.google.com/document/d/1ttSg_fLiw7G7Vv0MIjTG8Xd7h74XGKJdSMQPhwCz6x0/edit).
+        
+          - The New Stack editors are revising the article to shorten
+            it.
+          - Want to talk about article and KubeCon talk on podcast on
+            May 8th
+          - Georg and Nicole both available to do the podcast. 
+          - **AI Sarah:** Confirm with TNS.
+
+  - Grace Hopper Event opportunity for women in IT. CHAOSS invited to
+    participate in Oct. 1-4, pre-event for OS to give participants opp.
+    To work on development skills to contribute to an OS project.
+    Anything from Augur or GrimoireLab (CHAOSS software) related to D\&I
+    to ask students to work on, a panel, data component, expose students
+    to technology and begin to understand the goals of the project. 
+    
+      - > Daniel and Sean have ideas and number of things to contribute.
+        > 
+        
+          - GrimoireLab ideas:
+            
+              - > Improving SortingHat to support other definitions of
+                > diversity.
+            
+              - > Improve notebooks around D\&I (Perceval -\> notebooks
+                > -\> viz).
+            
+              - > Improve the Panels around D\&I (Kibana mainly).
+        
+          - Augur ideas: 
+            
+              - > Participants will have the opportunity to learn how to
+                > develop metrics derived from GitHub participation
+                > records using a Flask and javascript application
+                > framework. 
+            
+              - > Participants will implement open source metrics in
+                > Augur that they determine, through workshop
+                > participation, will help them understand which
+                > projects are supportive of including diverse
+                > newcomers. Methods in augur include machine learning
+                > focused on identifying non-inclusive communications in
+                > open source. 
+    
+      - > **AI Matt:** Take ideas/information from Daniel and Sean and
+        > fill out Google form. 
+
+  - Daniel invited by Google for workshop in June in SF, but not
+    providing funding for travel. Practical workshop for 2 days re:
+    D\&I. 
+
+  - Sponsoring Metric
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/135*](https://github.com/chaoss/wg-diversity-inclusion/issues/135)
+        > 
+    
+      - > Identified in level of completeness to work on and add to
+        > first release
+    
+      - > Review proposal right now 
+    
+      - > Daniel - what is the difference between mentorship and
+        > sponsorship? Is sponsorship less technical in nature? Geog
+        > believes sponsorship is geared toward getting members more
+        > involved but is less technical. More thoughts here:
+        > [*https://inclusion.slac.stanford.edu/sites/inclusion.slac.stanford.edu/files/The\_Key\_Role\_of\_a\_Sponsorship\_for\_Diverse\_Talent.pdf*](https://inclusion.slac.stanford.edu/sites/inclusion.slac.stanford.edu/files/The_Key_Role_of_a_Sponsorship_for_Diverse_Talent.pdf)
+    
+      - > Georg: Sponsor gives access to their own network, think of it
+        > as push and pull. Mentor pushes the mentee to be more active
+        > and do the right things. Sponsor pulls them in and helps
+        > increase their visibility. 
+    
+      - > Nicole: is it related to giving of opportunities? Mentor in a
+        > current role. 
+    
+      - > Differences are not very clear - not sure how to resolve. 
+    
+      - > **AI Georg: **identify sources for statistics in opening
+        > description
+    
+      - > **AI All:** Research topic further, including work of
+        > Yulkendy. 
+    
+      - > **AI Georg: **send email to mailing list to research further
+        > for next week’s discussion. 
+    
+      - > Review again next week.  
+
+  - Daniel: involved in InnerSource Commons all about breaking silos and
+    bringing OS way of working and methodology to companies. Recent D\&I
+    topic of discussion. InnerSource Commons discussion at KubeCon, how
+    to build internal communities, share some LF ideas that are working
+    in this area. 
+    
+      - > Invited Sarah and Nicole to MeetUp:
+        > https://www.meetup.com/InnerSource-Spain/events/260507248/
+
+  - Next week’s facilitator and notetaker
+    
+      - > Facilitator: Sarah
+    
+      - > Notes: Daniel
+
+<span id="anchor-144"></span>April 15, 2019
+
+Agenda:
+
+  - Review Action Items
+  - Go through focus areas and assess “Level of completeness”
+  - Discuss release strategy
+  - “CHAOSS D\&I WG: Past and Present”
+  - Google Season of Code participation
+  - Next week’s facilitator and notetaker
+
+Video: [*https://youtu.be/bzHPSU5vAsE*](https://youtu.be/bzHPSU5vAsE) 
+
+Notes:
+
+  - Attendees:
+    
+      - > Dawn Foster, Ry Jones, Georg Link, Sarah Conway, Sean Goggins,
+        > Daniel Izquierdo
+
+  - Review Action Items:
+    
+      - > **AI Georg:** Create a pull request to add the Mentorship
+        > metric to repo.
+        
+          - Done:
+            [*https://github.com/chaoss/wg-diversity-inclusion/pull/173*](https://github.com/chaoss/wg-diversity-inclusion/pull/173)
+          - Please review metric.
+          - Can we merge? - DONE
+    
+      - > **AI Georg:** Follow up with email about releasing metrics.
+        
+          - Done.
+          - Level of Completeness Exercise
+            ([*https://github.com/chaoss/wg-diversity-inclusion/issues/174*](https://github.com/chaoss/wg-diversity-inclusion/issues/174))
+            
+    
+      - > **AI Sarah:** Talk to Paris about KubeCon session.
+        
+          - Will reach out next week.
+    
+      - > **AI Nicole:** Talk to Jaice about KubeCon session.
+        
+          - No update.
+    
+      - > **AI Daniel:** Talk to Silona about KubeCon session.
+        
+          - No update.
+    
+      - > **AI Nicole and Georg: **Offered to co-author a blog on the
+        > Goal-Question-Metric approach. Where will blog live? Suggest
+        > targeting Opensource.com to target a broader audience. 
+        
+          - In progress
+    
+      - > **AI Sarah:** Send out a good first issue email on mailing
+        > list.
+        
+          - Will go out later this week.
+    
+      - > **AI Sarah:** take a look at Matt’s email about information
+        > needed here. 
+        
+          - Create our community bridge account and begin populating
+            with ideas for mentorship. Georg and Matt as mentors, but
+            need consensus around project focus / seasons.
+    
+      - > **AI Georg:** move the content from Emma’s proposal to a
+        > google doc and continue conversation on mailing list.
+        
+          - Open, focus discussion on release
+
+  - Go through focus areas and assess “Level of Completeness”
+    
+      - > Level of Completeness Exercise
+        > ([*https://github.com/chaoss/wg-diversity-inclusion/issues/174*](https://github.com/chaoss/wg-diversity-inclusion/issues/174))
+        > 
+        
+          - [*https://docs.google.com/spreadsheets/d/1\_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit\#gid=0*](https://docs.google.com/spreadsheets/d/1_jwkwzs8s6SAm2vVY-8lzTQk3YT0YpOveTlKOwjd2eQ/edit#gid=0)
+            
+    
+      - > Went through this during the end as a working meeting. See the
+        > doc for status and areas that still need some work before the
+        > release.
+
+  - Discuss release strategy
+    
+      - > Focus on sparse focus areas or flesh out existing metrics?
+        
+          - Some support during the meeting for making sure that we have
+            at least one metric in each focus area (Matt / Georg /
+            others).
+    
+      - > Our metrics are still exploratory and not all of them have
+        > been tested with real projects.
+    
+      - > **AI Georg:** General CHAOSS email list to get feedback from
+        > other WGs and lazy consensus on this decision. 
+
+  - “CHAOSS D\&I WG: Past and Present”
+    
+      - > [*https://docs.google.com/document/d/1ttSg\_fLiw7G7Vv0MIjTG8Xd7h74XGKJdSMQPhwCz6x0/edit*](https://docs.google.com/document/d/1ttSg_fLiw7G7Vv0MIjTG8Xd7h74XGKJdSMQPhwCz6x0/edit)
+    
+      - > Georg put this together for his dissertation and shared it
+        > with the working group as a resource we can use to spread
+        > awareness of the working group.
+    
+      - > Does the Linux Foundation have a preference for where this
+        > might find a good home?
+        
+          - Linux.com
+          - Maybe turn this into an interview or light publication
+          - Changelog
+          - Trade publications
+          - New Stack
+    
+      - > **AI All:** Please read and provide feedback.
+
+  - Google Season of Docs participation
+    
+      - > [*https://wiki.linuxfoundation.org/gsoc/2019-gsod-chaoss*](https://wiki.linuxfoundation.org/gsoc/2019-gsod-chaoss)
+    
+      - > Expansion of Google SoC programs to include docs, and the LF
+        > has an effort to participate, and CHAOSS plans to participate.
+        > The link above has some of our ideas and can amend it with
+        > other feedback.
+    
+      - > Need to be careful and make sure we aren’t over-extending
+        > ourselves with Community Bridge and other efforts requiring
+        > mentors.
+    
+      - > Timeline:
+        > [*https://developers.google.com/season-of-docs/docs/timeline*](https://developers.google.com/season-of-docs/docs/timeline)
+        > 
+
+  - Next week’s facilitator and notetaker
+    
+      - > Do not cancel April 22 due to Easter Monday holiday in some
+        > regions
+    
+      - > Facilitator: Georg
+    
+      - > Notetaker: Sarah
+
+<span id="anchor-145"></span>April 8, 2019
+
+Agenda:
+
+  - Review Action Items
+  - Start requiring DCO on D\&I repository ([*issue
+    \#170*](https://github.com/chaoss/wg-diversity-inclusion/issues/170))
+  - Community Bridge
+  - Pilot D\&I metrics, Emma’s doc:
+    [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/assessment-packages/small-leadership.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/assessment-packages/small-leadership.md)
+  - Releasing D\&I metrics: what are our criteria for “released” metrics
+  - Facilitator and Notetaker for next week
+
+Video: [*https://youtu.be/-Gc13iJD7do*](https://youtu.be/-Gc13iJD7do) 
+
+Notes: 
+
+  - Attendees; Ry Jones, Georg Link, Sean Goggins, Sarah Conway, Matt
+    Germonprez, Dawn Foster
+
+  - Review Action Items:
+    
+      - > **AI Georg**: put together a description for OSSNA submission,
+        > circulate on mailing list, submit before deadline tomorrow
+        
+          - Done, submitted
+    
+      - > **AI Georg:** Lazy consensus on mailing list by end of week.
+        > To fix MIT license
+        
+          - Done. Pull request is merged.
+    
+      - > **AI Georg:** Announce on mailing list and activate DCO bot.
+        
+          - Done. Bot is active. DCO is required.
+    
+      - > **AI Georg:** Create a pull request to add the Mentorship
+        > metric to repo.
+        
+          - Done:
+            [*https://github.com/chaoss/wg-diversity-inclusion/pull/173*](https://github.com/chaoss/wg-diversity-inclusion/pull/173)
+          - Please review met 
+    
+      - > **AI Georg:** follow up with email about releasing metrics
+        
+          - Outstanding
+    
+      - > **AI Sarah:** Talk to Paris about KubeCon session
+        
+          - Open
+    
+      - > **AI Nicole:** Talk to Jaice about KubeCon session
+        
+          - No update 
+    
+      - > **AI Daniel:** Talk to Silona about KubeCon session
+        
+          - No update
+    
+      - > **AI Nicole and Georg: **offered to co-author a blog on this
+        > topic. Where will blog live? Suggest targeting Opensource.com
+        > to target a broader audience. 
+        
+          - Ongoing, started a draft
+
+  - Workflow improvement
+    
+      - > When we add a new metric, make sure to mention @germonprez in
+        > the comment so that he can add the metric to the chaoss/metric
+        > repository.
+
+  - **AI Sarah:** Sendout a good first issue email on mailing list
+
+  - Start requiring DCO on D\&I repository ([*issue
+    \#170*](https://github.com/chaoss/wg-diversity-inclusion/issues/170))
+    
+      - > DCO is now required for all new commits.
+
+  - Community Bridge
+    
+      - > **AI Sarah:** take a look at Matt’s email about information
+        > needed here. 
+
+  - Pilot D\&I metrics, Emma’s doc:
+    [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/assessment-packages/small-leadership.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/assessment-packages/small-leadership.md)
+    
+      - > **AI Georg:** move the content to a google doc and continue
+        > conversation on mailing list.
+    
+      - > Maybe take a marketing perspective and create a different
+        > format, like an infographic.
+    
+      - > Goal of this document: provide a path for communities to start
+        > considering D\&I
+    
+      - > 1-page or 1-slide that can be included in future talks 
+
+  - Releasing D\&I metrics: what are our criteria for “released” metrics
+    
+      - > (In order of rough preference as discussed in the meeting.) If
+        > we have a focus area with 2 out of 5 metrics well developed,
+        > we can …
+        
+          - 1\. We can have a generic disclaimer in each incomplete
+            focus area, that there are more under development and they
+            can be found on the repository
+            
+              - > Way to get more contributors who are interested in
+                > helping to develop incomplete metrics.
+        
+          - 2\. We can hold back the other 3 metrics for future
+            releases.
+        
+          - 3\. We can include undeveloped metrics with a disclaimer
+            that they are undeveloped.
+    
+      - > Should we focus on a specific metric for the first release?
+        
+          - We should do a walk-through of the focus areas and metrics
+            to identify the “level of completeness”.
+          - Then, we can decide whether to focus on the focus-areas that
+            have the most complete OR to focus on metrics that could
+            populate a less well developed focus area.
+          - We will put this on next week’s agenda and prior discuss
+            this on the mailing list.
+
+  - Facilitator and Notetaker for next week
+    
+      - > Facilitator: Sarah
+    
+      - > Notetaker: Dawn
+
+<span id="anchor-146"></span>April 1, 2019
+
+Agenda:
+
+  - OSSNA submission
+  - Review Action items
+  - Relicense D\&I repository ([*pr
+    \#169*](https://github.com/chaoss/wg-diversity-inclusion/pull/169))
+  - Start requiring DCO on D\&I repository ([*issue
+    \#170*](https://github.com/chaoss/wg-diversity-inclusion/issues/170))
+  - Community Bridge (email from Matt)
+  - Work on Mentorship metric ([*issue
+    \#120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120))
+  - Pilot D\&I metrics, Emma’s doc:
+    [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/assessment-packages/small-leadership.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/assessment-packages/small-leadership.md)
+  - Releasing D\&I metrics: what are our criteria for “released” metrics
+  - Determine facilitator and notetaker for next time
+
+Video: [*https://youtu.be/m7SrD4HTbv0*](https://youtu.be/m7SrD4HTbv0) 
+
+Notes:
+
+  - Attendees: Ry Jones, Georg Link, Sean Goggins, Matt Germonprez, Dawn
+    Foster, Nicole Huesman
+
+  - OSSNA submission for D\&I talk
+    
+      - > What to include in presentation
+        
+          - Processes for collecting D\&I data
+        
+          - Pick some of the metrics and talk about how to gather them
+        
+          - Briefly introduce the work that has already been done
+        
+          - Pitch: How to build a D\&I report
+            
+              - > Focus on process (⅔)
+            
+              - > What metrics
+            
+              - > How to collect metrics
+            
+              - > Examples for metric (last quarter)
+    
+      - > **AI Georg**: put together a description, circulate on mailing
+        > list, submit before deadline tomorrow
+
+  - Review Action Items
+    
+      - > **AI Sarah:** Send notes from Hyperledger meeting to D\&I
+        > mailing list
+        
+          - [*https://docs.google.com/document/d/18fpwuxjxNgIDcBMcuNQnD2j2z8Wypb6TnRfsL9pWFLg/edit*](https://docs.google.com/document/d/18fpwuxjxNgIDcBMcuNQnD2j2z8Wypb6TnRfsL9pWFLg/edit)
+    
+      - > **AI Nicole:** reach out to see if Microsoft .NET contact
+        > would like to join D\&I working group. 
+        
+          - Open
+    
+      - > **AI Georg: **send out what are the requirements to become a
+        > pilot project, how much time is required via mailing list for
+        > further discussion. 
+        
+          - Done
+    
+      - > **AI Nicole and Georg: **offered to co-author a blog on this
+        > topic. Where will blog live? Suggest targeting Opensource.com
+        > to target a broader audience. 
+        
+          - Ongoing, started a draft
+    
+      - > **AI Sarah:** Talk to Paris about KubeCon session
+        
+          - No update
+    
+      - > **AI Nicole:** Talk to Jaice about KubeCon session
+        
+          - Open 
+    
+      - > **AI Daniel:** Talk to Silona about KubeCon session
+        
+          - No update
+    
+      - > **AI Georg:** Send an email to the D\&I mailing list about
+        > releasing metrics
+        
+          - **AI Georg:** follow up
+    
+      - > **AI Nicole:** Submit PR with new readme file and review at
+        > next meeting. 
+        
+          - Done:
+            [*\#172*](https://github.com/chaoss/wg-diversity-inclusion/pull/172)
+
+  - Relicense D\&I repository ([*pr
+    \#169*](https://github.com/chaoss/wg-diversity-inclusion/pull/169))
+    
+      - > Decision to merge to reduce future issue with license.
+    
+      - > **AI Georg:** Lazy consensus on mailing list by end of week.
+
+  - Start requiring DCO on D\&I repository ([*issue
+    \#170*](https://github.com/chaoss/wg-diversity-inclusion/issues/170))
+    
+      - > Activate bot.
+    
+      - > **AI Georg:** Announce on mailing list and activate DCO bot.
+
+  - Community Bridge
+    
+      - > Wait for more core contributor input
+
+  - Work on Mentorship metric ([*issue
+    \#120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120))
+    
+      - > Reviewed and edited Mentorship metric.
+    
+      - > **AI Georg:** Create a pull request to add the Mentorship
+        > metric to repo.
+
+  - Pilot D\&I metrics, Emma’s doc:
+    [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/assessment-packages/small-leadership.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/assessment-packages/small-leadership.md)
+    
+      - > Details need some work
+    
+      - > What is the focus 
+
+  - Releasing D\&I metrics: what are our criteria for “released” metrics
+    
+      - > The ethical guideline is still being debated on the mailing
+        > list, we don’t have that yet to put into a package
+    
+      - > Requirement for “compensated” could be “rewarded” instead.
+    
+      - > Next step: Think about it more?
+
+  - Determine facilitator and notetaker for next time
+    
+      - > Facilitator: Georg
+    
+      - > Notetaker: TBD
+
+<span id="anchor-147"></span>March 25, 2019
+
+Agenda:
+
+  - Postponed to following week
+
+Video: not recorded
+
+Notes:
+
+  - Attendees: Georg Link, Matt Germonprez, Daniel Izquierdo
+
+  - Relicense D\&I repository ([*pr
+    \#169*](https://github.com/chaoss/wg-diversity-inclusion/pull/169))
+    
+      - > Added @germonprez because he shows up on the CHAOSS.biterg.io
+        > dashboard
+    
+      - > Added @vchrombie, because we accepted pull request 
+
+  - Work on Mentorship metric ([*issue
+    \#120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120))
+    
+      - > Revised sample strategies and sample metrics
+
+  - Determine facilitator and notetaker for next time
+    
+      - > Facilitator: Georg
+    
+      - > Notetaker: TBD
+
+<span id="anchor-148"></span>March 18, 2019
+
+Agenda:
+
+  - Recap last week
+    
+      - > Hyperledger Meeting 
+    
+      - > Panel Discussion
+    
+      - > CHAOSS 30 minutes BoF
+
+  -  Accepted to speak at KubeCon Barcelona
+
+  -  Update from GB meeting
+
+Video: not recorded
+
+Notes
+
+  - Karsten Wade, Sarah Conway (Notetaker), Daniel Izquierdo, Georg Link
+    (facilitator), Nicole Huesman
+
+  - Karsten works with Langdon and BU. Hyperledger committee working on
+    D\&I.
+
+  - Recap last week’s Open Source Leadership Summit
+    
+      - > Hyperledger Meeting 
+        
+          - **AI Sarah:** Send notes from meeting to D\&I mailing list
+          - HL decentralized identity management with Indy, incorporate
+            methods for reporting on D\&I. Once deployed with this tool,
+            it will be available to other communities. 
+          - First trial with Hyperledger community.
+          - Next step is to meet with the Indy team
+            (https://www.hyperledger.org/projects/hyperledger-indy).
+    
+      - > Panel Discussion on D\&I metrics at OSLS.
+        
+          - Panelists: Nicole, Sarah, Dawn and Georg.
+          - Discussion about where we are in the D\&I working group and
+            expectations for the following months and looking for
+            piloting.
+          - Ethics discussion, pilot use cases interesting to crowd.
+            Validated work as it resonates with people.
+          - Microsoft approached Nicole, from .Net Foundation. 
+          - **AI Nicole:** to reach out to see if contact would like to
+            join D\&I workgroup. 
+    
+      - > CHAOSS 30 minutes BoF
+        
+          - Georg comment: requirements to become a pilot project, time
+            involved, would be good to document this and post it so we
+            can point people to it. Good discussion to also post to
+            mailing list for wider input and further discussion. 
+            
+              - > **AI Georg: **send out what are the requirements to
+                > become a pilot project, how much time is required via
+                > mailing list for further discussion. 
+        
+          - D\&I 3 Focus Areas This Year 1) evolve the metrics based on
+            community input, continue to work on them, 2) application of
+            the metrics and the pilot projects and 3) socialization,
+            promotion of the successes, increase visibility for CHOASS
+            and the pilot project successes 
+            
+              - > Nicole: do we develop a plan we want to make sure we
+                > publish a blog each month, interview
+            
+              - > AI Nicole & Sarah: develop a plan with regular
+                > activities to pursue to increase awareness of D\&I
+                > workgroup. 
+        
+          - Created awareness, different workgroups presented
+        
+          - Around 15 people attended 
+        
+          - Lots of discussion on D\&I, pilot use cases 
+        
+          - Lots of focus on Risk, what direction these metrics should
+            take? 
+            
+              - > How did we come up with these metrics? goal, question,
+                > objective, metrics to answer those questions 
+            
+              - > How well understood is this process within the larger
+                > community? Have we done a blog the development of
+                > metrics? The process, philosophy, how to avoid gaming
+                > the system with the metrics. No, there is no blog on
+                > this. 
+            
+              - > **AI Nicole and Georg: **offered to co-author a blog
+                > on this topic. Where will blog live? Suggest targeting
+                > Opensource.com to target a broader audience. 
+
+  -  Accepted to speak at KubeCon Barcelona
+    
+      - > What do we see as panel discussion for KubeCon? Daniel asked
+        > if we should talk about more of the same? Discussion on
+        > ethics? Pilot project as a focus resonates. How time intensive
+        > is it to get involved? Depends on project and the scope of the
+        > project they take on. K8s much different than a smaller
+        > project. If we are going to push pilot project as a call to
+        > action, projects are naturally going to ask about the time
+        > commitment involved. 
+    
+      - > Focus at KubeCon on what CNCF and Kubernetes is already
+        > working on. Draw connection with CHAOSS work. Maybe do some
+        > qualitative research to know what they are doing with regards
+        > to D\&I metrics.
+    
+      - > Maybe interview or speak with a few people.
+        
+          - Paris Pittman, Jaice Singer DuMars, Dawn Foster, Silona 
+          - **AI Sarah:** Talk to Paris 
+          - **AI Nicole:** Talk to Jaice 
+          - **AI Daniel:** Talk to Silona
+
+  - Update from GB meeting
+    
+      - > Release metrics - will be released on the website, version by
+        > date, will version entire release, up to working groups what
+        > gets released. 
+    
+      - > Will be on D\&I workgroup to say these metrics are ready to be
+        > released and submit them to a release process - yet to be
+        > defined. 
+    
+      - > Will have a release candidate, 2 week review before we launch
+        > it. Part of the release, is also desire metrics can be
+        > implemented. 
+    
+      - > Whatever we release should be useable. 
+    
+      - > Also one of the D\&I workgroup goals, so that aligns. 
+    
+      - > We now have closure on how to release and can now focus on how
+        > to release the metrics. 
+    
+      - > Should have more information on when first release will be at
+        > next meeting on April 2.
+    
+      - > We need to decide which metrics to have ready for the release,
+        > determine when do we call a metric stable, feel comfortable
+        > releasing it, document our process and then clean those up. 
+    
+      - > Goal Objective \#5:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/goals-2019.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/goals-2019.md)
+        > 
+    
+      - > **AI Georg:** Send an email to the D\&I mailing list about
+        > releasing metrics
+
+  - CHAOSS Community Handbook: within growing CHAOSS, newcomers, don’t
+    know history, especially for someone new it can be difficult, not a
+    lot documented with roles and responsibilities. 
+
+  - Community Handbook idea - GitLab has published all their operations.
+    Idea is to adopt that for CHAOSS and document how we operate. 
+
+  - Several willing to help write it. 
+
+<span id="anchor-149"></span>March 4, 2019
+
+Agenda:
+
+  - Recruit a notetaker
+  - OSLS items & should we cancel next week?
+  - Review last week’s Action Items
+  - Updates on RH/BU D\&I Interns
+  - Metrics around pull request
+  - Metrics around communication channel 
+  - Other items ???
+  - Determine the March 18th meeting facilitator and notetaker 
+
+Video Recording:
+[*https://www.youtube.com/watch?v=EoUuWET6Z8Y*](https://www.youtube.com/watch?v=EoUuWET6Z8Y)
+
+Notes:
+
+  - Participants: Dawn Foster, Sean Goggins, Georg Link, Langdon, Sarah
+    Conway, Kevin Lumbard, Emmanuel Amposah, Daniel Izquierdo.
+
+  - Notetaker: Daniel.
+
+  - Review last week’s Action Items:
+    
+      - > **AI Sarah:** Send bi-weekly reminder of issues that we want
+        > help with. Bring this up during meeting to get ideas for what
+        > issues to include. Use overall CHAOSS mailing list.
+        
+          - After this call today, Sarah will look for easy ways to get
+            involved and send the call every other Monday.
+    
+      - > **AI Georg:** Start conversations on the CHAOSS mailing list
+        > on topics that bleed over from the weekly calls.
+        
+          - This is ongoing and Georg has it on his agenda.
+    
+      - > **AI Matt + Kevin:**
+        > [*https://github.com/chaoss/website/issues/118*](https://github.com/chaoss/website/issues/118)
+        
+          - Matt and Kevin will work on this in the following days.
+            There are issues where there’s some on going discussion.
+            Feedback is welcome.
+    
+      - > **AI Sarah:** Setup meeting with Hyperledger and CHAOSS D\&I
+        
+          - Wednesday afternoon seems to work for everyone.
+            
+              - > We may require some phone connection.
+    
+      - > **AI Daniel:** Reach out to Uber and invite them to OSLS
+        > meeting as well
+        
+          - When are we having this meeting?
+          - Shall we have a meetup during the OSLS? Uber might be
+            invited to this meeting.
+          - **AI Sarah** will check with the TLF team to double check if
+            there are BOFs
+    
+      - > **AI Daniel:** Create a pull request that add people who
+        > contributed at CHAOSScon as contributors
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/pull/168*](https://github.com/chaoss/wg-diversity-inclusion/pull/168)
+          - Daniel to check this with the Eventbrite info.
+    
+      - > **AI Sarah:** confirm with everyone that the switch from
+        > Daniel to Jamie is okay for the OSLS panel.
+        
+          - Done. Reflected in the program.
+          - Georg may introduce part of the data.
+    
+      - > **AI Sarah:** Update panelist bio section on OSLS schedule.
+        > Georg replaces Matt, Jamie replaces Daniel.
+        
+          - Done. Reflected in the program.
+    
+      - > **AI Nicole:** Schedule a OSLS panel planning meeting.
+        > Strategy for fitting this many people in a 30 minute panel.
+        
+          - Done.
+    
+      - > **AI Nicole:** Send email to overall CHAOSS mailing list to
+        > start review process for README.
+        
+          - Done.
+    
+      - > **AI Nicole:** Submit PR with new readme file and review at
+        > next meeting. 
+        
+          - Ongoing.
+
+  - Open Source Leadership Summit:
+    
+      - > Are there any topics we’d like to discuss about?
+    
+      - > Cancelling next week meeting?
+        
+          - This is cancelled because many of us are travelling to the
+            OSLS
+          - **AI Matt**: Send next meeting cancellation.
+
+  - Updates on RH/BU D\&I Interns
+    
+      - > Emmanuel: They already have a couple of people to work on the
+        > D\&I (have a look at previous notes from previous meetings)
+    
+      - > Langdon: Giving them background work. They hope to start the
+        > week after next. 
+    
+      - > Questions: other ways to connect interns in addition to these
+        > calls? Other ways to be proactive?
+        
+          - They’ll be given a bunch of resources (CHAOSS, D\&I in
+            general). This is an onboarding process. Metrics for D\&I
+            focus.
+          - Connecting with the technology might be hard, but mentors
+            have already started to talk to Sean about Augur.
+          - They may send emails to the mailing lists.
+
+  - Metrics around pull request
+    
+      - > Emmanuel, they were having a look at the metrics in CHAOSS,
+        > contributions types, how to make a PR. They didn’t find a
+        > proper way to include some metrics without moving things
+        > around.
+    
+      - > Dawn: not all of the metrics might be part of D\&I. There are
+        > other groups such as the commons working group, GMD, Risk, and
+        > others. It might be worth having a look at this.
+    
+      - > Langdon: It was unclear the relationship between the overall
+        > metrics and the D\&I metrics and how they relate to each
+        > other. Was this intended?
+        
+          - Example of those metrics: responsiveness metrics such as
+            time to xxx.
+    
+      - > There’s a document that they’ll share with the community to
+        > have a look at and help with the process.
+        
+          - CHAOSS is still doing work in progress in terms of
+            structuring all of the metrics and across all of the working
+            groups.
+    
+      - > Example of metrics: communication channels and sentiment and
+        > inclusivity in those channels. 
+
+  - Determine the March 18th meeting facilitator and notetaker 
+    
+      - > Facilitator: Nicole as tentative facilitator
+    
+      - > Notetaker: Sarah Conway
+
+  - OSLS panel
+    
+      - > Nicole will moderate the panel.
+    
+      - > Potential recommendations:
+        
+          - Slide with panelist introductions.
+          - 1 Question per panelist and then there’s time for extra
+            questions from the audience.
+
+<span id="anchor-150"></span>February 25, 2019
+
+Agenda:
+
+  - Ways to contribute for people not on a call
+  - Review last week’s Action Items
+  - Outreachy discussion 
+  - Determine next week’s meeting facilitator and notetaker 
+  - Other…
+
+Note:
+
+  - Participants: Ry Jones, Dawn Foster, Georg Link, Matt Germonprez,
+    Langdon, Sarah Conway, Nicole Huesman, Lars Kiesow, Kevin Lumbard,
+    Lars Kiesow
+
+  - Ways to contribute for people not on a call
+    
+      - > The goal is to include people in the repository. Have events
+        > or include in meeting minutes issues that anyone could pick up
+        > to participate.
+    
+      - > We have loads of stuff on the issue tracker that anyone could
+        > pick up. We need to explicitly encourage people to
+        > participate. 
+    
+      - > People who are not on the call may feel that they are not up
+        > to speed and have a barrier to contribute
+    
+      - > We should continue to use the “good first issue” tag on the
+        > issue tracker
+    
+      - > Maybe have a regular email to mailing list with issues that we
+        > would like help with.
+        
+          - **AI Sarah:** Send bi-weekly reminder of issues that we want
+            help with. Bring this up during meeting to get ideas for
+            what issues to include. Use overall CHAOSS mailing list.
+    
+      - > Rehash a conversation via an email thread that is unique to
+        > one topic. Especially topics we could not conclude during a
+        > meeting. Use CHAOSS mailing list for larger conversations 
+        
+          - Use D\&I list for updates, agenda, and organization issues
+          - **AI Georg:** Start conversations on the CHAOSS mailing list
+            on topics that bleed over from the weekly calls.
+    
+      - > The D\&I mailing list is missing on the
+        > chaoss.community/participate section “mailing lists”
+        
+          - **AI Matt + Kevin:**
+            [*https://github.com/chaoss/website/issues/118*](https://github.com/chaoss/website/issues/118)
+
+  - Review last week’s Action Items
+    
+      - > **AI Daniel:** talk to Nicole whether she wants to be panelist
+        > or moderator (OSLS)
+        
+          - Nicole is happy to do either, whatever is needed.
+        
+          - Jamie Smith is willing to take Daniel’s spot on the panel.
+            
+              - > **AI Sarah:** confirm with everyone that the switch
+                > from Daniel to Jamie is okay for the OSLS panel.
+        
+          - Georg is taking Matt’s place on the panel
+            
+              - > **AI Sarah:** Update panelist bio section on OSLS
+                > schedule. Georg replaces Matt, Jamie replaces Daniel.
+        
+          - **AI Nicole:** Schedule an OSLS panel planning meeting.
+            Strategy for fitting this many people in a 30 minute panel.
+    
+      - > **AI Sarah:** Setup meeting with Hyperledger and CHAOSS D\&I
+        
+          - Ongoing. Hyperledger team meets internally first. 
+          - At OSLS, include a remote join option for people who can’t
+            be at the meeting
+          - Hyperledger is very interested in using D\&I metrics.
+            Working internally to get started, evaluating how to use
+            CHAOSS metrics effectively and how to contribute back.
+          - Invite for meeting at OSLS will come later this week.
+    
+      - > **AI Daniel:** Reach out to Uber and invite them to this
+        > meeting as well
+        
+          - Open
+    
+      - > **AI Georg + Matt:** prepare a intern project description
+        
+          - Done:
+            [*https://github.com/chaoss/wg-diversity-inclusion/issues/166*](https://github.com/chaoss/wg-diversity-inclusion/issues/166)
+            
+    
+      - > **AI Daniel:** Create a pull request that add people who
+        > contributed at CHAOSScon as contributors
+        
+          - Open
+    
+      - > **AI Nicole:** communicate with Ben on D\&I ReadMe file and
+        > move content into these sections. 
+        
+          - Content update:
+            
+              - > [*https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit*](https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit)
+        
+          - **AI Nicole:** Send email to overall CHAOSS mailing list to
+            start review process
+    
+      - > **AI Nicole:** Submit PR with new readme file and review at
+        > next meeting. 
+        
+          - After email-list review
+
+  - Outreachy discussion 
+    
+      - > Question: The last two project ideas have an overlap with a
+        > Boston University project. Concern is limited time from
+        > mentors and adding more interns might spread mentors thin. 
+        
+          - The metrics chosen by BU students are: Communication and
+            Pull Requests
+          - BU goal is to implement with Augur and GrimoireLab and
+            document different visualization and representation options.
+          - BU has three part-time interns.
+          - BU project may extend into summer and fall as an ongoing
+            project for students to accomplish goals. Summer interns
+            would be full-time.
+          - **AI BU project: **Provides updates on weekly D\&I call.
+    
+      - > Decision: Wait for BU project to evolve and evaluate how much
+        > work goes into mentoring before we add more interns.
+
+  - Determine next week’s meeting facilitator and notetaker 
+    
+      - > Facilitate: Dawn Foster
+    
+      - > Notetaker: TBD at beginning of meeting
+
+<span id="anchor-151"></span>February 18, 2019
+
+Agenda:
+
+  - OSLS Panel change
+  - CHAOSS D\&I meeting at OSLS
+  - Outreachy intern follow up
+  - BU + Red Hat Open Source Inclusion Update
+  - Review last week’s Action Items
+  - \[Objective \#5, KR1\] Update on metric release infrastructure
+  - \[Objective \#5, KR1\] Advancing metrics from CHAOSScon workshop
+  - Determine next week’s meeting facilitator and notetaker 
+  - Other…
+
+Notes:
+
+  - Participants:Daniel Izquierdo (Facilitator), Georg Link (Notetaker),
+    Matt Germonprez, Matt Snell, Sarah Conway, Emmanuel Amponsah
+
+  - OSLS Panel Change
+    
+      - > Session: [*https://sched.co/LG3N*](https://sched.co/LG3N)
+    
+      - > Georg is replacing Matt 
+    
+      - > We can come up with some questions for the panel. If it makes
+        > sense to have someone from Hyperledger on the panel, Daniel
+        > would offer his seat on the panel.
+    
+      - > **AI Daniel:** talk to Nicole whether she wants to be panelist
+        > or moderator
+
+  - CHAOSS D\&I meeting at OSLS
+    
+      - > This is a CHAOSS D\&I meeting
+    
+      - > Invite Hyperledger 
+    
+      - > **AI Sarah:** Setup meeting with Hyperledger and CHAOSS D\&I
+    
+      - > Another potential case study for D\&I metrics could be the
+        > Zephyr project
+    
+      - > **AI Daniel:** Reach out to Uber and invite them to this
+        > meeting as well
+    
+      - > Question: how do we make the connection between CHAOSS D\&I WG
+        > and projects that want to implement the metrics?
+    
+      - > How do we, firstly, get them aware of the project and,
+        > secondly, become involved.
+    
+      - > Maybe we need a package or document on “how to get started
+        > with D\&I metrics”
+    
+      - > Three possible methods:
+        
+          - CHAOSS D\&I members do the work of implementing D\&I metrics
+            for communities. E.g., produce a gender report for a
+            community
+          - We have an Outreachy or other intern who does the D\&I
+            implementation
+          - CHAOSS D\&I members as consultants, providing guidance to a
+            project, providing help but not doing work ourselves.
+          - Find sponsoring (open call?) to have a full-time dedicated
+            CHAOSS D\&I person who can be a liaison with projects
+
+  - Outreachy intern follow up
+    
+      - > **AI Georg + Matt:** prepare a project description
+
+  - BU + Red Hat Open Source Inclusion Update
+    
+      - > Two weeks ago, BU + Red Hat had a round table on what metrics
+        > they wanted to work on
+        > ([*graphic*](https://drive.google.com/file/d/12HEtALiey93CCPYALeDLWLj6DuepDqF_/view?usp=sharing)).
+        > Through a voting, two metrics were surfaced that the team is
+        > thinking about working on. Question is now, whether the CHAOSS
+        > D\&I Working Group has feedback on these metrics.
+    
+      - > Metrics would be integrated with Augur
+    
+      - > 1\. Metric: Communication channels + sentiment
+        
+          - Not yet defined in CHAOSS D\&I WG
+          - [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/channels.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/focus-areas/project-and-community/channels.md)
+          - Good starting point, needs defining, space for innovation
+            and students can shape the outcome
+    
+      - > 2\. Metric: Pull requests and reviews on GitHub
+        
+          - Might be related to focus area “Recognition of Good Work” 
+          - [*https://github.com/chaoss/wg-diversity-inclusion/tree/master/focus-areas/recognition*](https://github.com/chaoss/wg-diversity-inclusion/tree/master/focus-areas/recognition)
+          - Not yet defined in CHAOSS D\&I Working Group
+          - 
+    
+      - > Next steps: Dive into the metrics and what can be collected.
+        > Talk to Augur about how already collected metrics can be used
+        > for D\&I metrics. 
+    
+      - > Suggestion: Identify the goal first, irrespective of metric.
+        > Work through several steps to work towards a metric. (Avoid
+        > limiting search to metrics based on already available data).
+
+  - Review last week’s action items:
+    
+      - > **AI Daniel:** Create a pull request that add people who
+        > contributed at CHAOSScon as contributors
+        
+          - open
+    
+      - > **AI Nicole:** communicate with Ben on D\&I ReadMe file and
+        > move content into these sections. 
+        
+          - open
+    
+      - > **AI Nicole:** Submit PR with new readme file and review at
+        > next meeting. 
+        
+          - open
+    
+      - > **AI Georg + Matt:** prepare a project description
+        
+          - Open
+    
+      - > **AI Germonprez:** Common Metrics WG requested: on Metrics
+        > repository, on the long list of metrics, add column with what
+        > WG works on each metric and link to the respective repo. This
+        > week, working on D\&I metrics. Possible pull requests coming
+        > to align e.g., naming. \[due: Thursday\]
+        
+          - Work in progress: https://github.com/germonprez/metrics
+          - Goal: Common Metrics WG wants to identify important metrics
+            that are not worked on in any other WG yet.
+
+  - \[Objective \#5, KR1\] Update on metric release infrastructure
+    
+      - > Update from last week’s CHAOSS weekly hangout call: The
+        > infrastructure is not decided on yet. The previous proposal
+        > was 
+
+  - \[Objective \#5, KR1\] Advancing metrics from CHAOSScon workshop
+    
+      - > **AI Daniel:** Review the google docs and decide whether they
+        > are good enough for a pull request (and create a pull request)
+        > otherwise, report back to meeting next week which metrics need
+        > more work. Write a comment with conclusion on the respective
+        > issue.
+
+  - Determine next week’s meeting 
+    
+      - > Facilitator: Sarah Conway
+    
+      - > Notetaker: Georg Link
+
+  - Other…
+    
+      - > Call for conference speakers is open for late October
+        
+          - Grace Hopper, due March
+            
+              - > Nicole, Sarah have expressed interest
+        
+          - All Things Open, due March
+            
+              - > Anyone going and interested in presenting about D\&I
+                > metrics?
+        
+          - Open Source Summit Europe
+            
+              - > Anyone going and interested in presenting about D\&I
+                > metrics?
+            
+              - > Daniel will be going
+
+<span id="anchor-152"></span> February 11, 2019
+
+Agenda:
+
+  - Review on last week’s Action Items
+  - \[Objective 1, KR1\] Discussion on potential new use cases for the
+    D\&I use cases (e.g.: Hyperledger). 
+  - \[Objective \#5, KR2\] Mailing list discussion about the readme plus
+    cohesion with the GMD WG.
+  - Determine next week’s meeting facilitator and notetaker 
+  - \[Objective \#5, KR1\] Subdomain for metrics release 
+  - \[Objective \#5, KR1\] Advancing metrics from CHAOSScon workshop
+  - Other…
+  - 
+
+Notes:
+
+  - Participants: Dawn Foster, Georg Link, Daniel Izquierdo, Sharan,
+    Langdon, Sarah Conway, Emmanuel Amponsah, Matt Germonprez, Nicole
+    Huesman, Kevin Lumbard
+
+  - Review last week’s Action Items
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - Open - postpone until next week 
+    
+      - > **AI All:** Weigh in on the structure by next week, using
+        > comments in the Google Doc. **AI Nicole:** Send email to list
+        > to ask for feedback on readme structure.
+        
+          - Posted to mailing list for feedback. A few comments were
+            made on the document. Discussed more in later agenda item
+    
+      - > **AI Georg:** create new pull request
+        > ([*https://github.com/chaoss/wg-diversity-inclusion/pull/158*](https://github.com/chaoss/wg-diversity-inclusion/pull/158))
+        
+          - Sarah: Paid and non-paid adds more clarity
+          - Sharan: tried to capture this too and saw it as a
+            distinction worth capturing
+          - Dawn: incredibly important to capture, need to consider how
+            the info. Is used
+          - Agreed to use language, Dawn to go ahead and merge 
+    
+      - > **AI Matt**: Look for funding for outreachy / GSoC
+        
+          - Matt: Not much luck with funding. 
+          - Involve someone who can help us polish what we have, use
+            cases that we have, work with more projects to implement
+            metrics, could use someone to collect the information, write
+            engaging blog posts. 
+          - Red Hat and Linux Foundation may be able to support this in
+            future. Red Hat has money earmarked for a project we have
+            with Open Source & D\&I (and funds Outreachy interns in
+            general). Would need more specifics - one paragraph - on
+            what is needed. 
+          - **AI Georg + Matt:** prepare a project description
+    
+      - > **AI Georg:** Create a Pull Request to add contributors to
+        > readme
+        
+          - Done
+    
+      - > **AI Daniel:** Create a pull request that add people who
+        > contributed at CHAOSScon as contributors
+        
+          -  Open
+
+  - Discussion on potential new use cases for the D\&I use cases (e.g.:
+    Hyperledger). \[Objective \#1\]
+    
+      - > What needs to happen for Hyperledger to become a pilot
+        > project?
+        
+          - Examples OpenStack - Daniel’s suggestion is to start with
+            one focus area, the one most useful, easiest and move
+            forward. Data for governance, for example, is it useful for
+            the board, community. Will it help the board make decisions,
+            become more inclusive. 
+        
+          - Nicole: Hyperledger interested in doing D\&I work, measuring
+            it, follow OpenStack example. 
+        
+          - Daniel: we don’t know how much work involved in a use case
+            from both sides - start small with one focus area. 
+        
+          - Nicole: initial D\&I work had deadlines around OpenStack
+            Summits, writing blogs around the work. Event specific to
+            Hyperledger community. 
+        
+          - Sarah: Hyperledger events in 2019 - what can project commit
+            to, focus on? Might be an opportunity for D\&I focus. 
+        
+          - Nicole: OpenStack reports covered majority of metric
+            categories in CHAOSS D\&I work. 
+        
+          - Understand Hyperledger goals and how they match to CHAOSS
+            D\&I goals. Copied from WG repo:
+            
+              - > Goal: Identify how we are communicating with
+                > contributors, and potential contributors.
+            
+              - > Goal: Identify the diversity of the contributions
+                > within a community, and how those different
+                > contributions are valued.
+            
+              - > Goal: Identify the diversity and inclusion at events.
+        
+          - CHAOSS D\&I serve as consultants for Hyperledger project
+            once goals identified. 
+        
+          - **AI Sarah:** Contact Hyperledger project and discuss which
+            focus group is most interesting for the project to start
+            with. 
+        
+          - **AI Sarah:** Schedule an in-person meeting at OSLS. Dawn
+            will be there, happy to help. 
+        
+          - Georg: Is there anything CHAOSS D\&I should do/prepare? 
+        
+          - Sarah: Is there any success from OpenStack that exists to
+            share? 
+        
+          - Nicole: Is there one case study to share? We don’t have that
+            yet. Point to the different blogs about the OpenStack
+            Report. Share this with Hyperledger team/members. 
+            
+              - > very first report:
+                > [*http://superuser.openstack.org/articles/bitergia-intel-report/*](http://superuser.openstack.org/articles/bitergia-intel-report/)
+                > (check at the end the link to the PDF)
+            
+              - > Mentorship focus report:
+                > [*http://superuser.openstack.org/articles/2018-gender-diversity-report/*](http://superuser.openstack.org/articles/2018-gender-diversity-report/)
+                > (PDF at the end of the post)
+
+  - Mailing list discussion about the readme plus cohesion with the GMD
+    WG. \[Objective \#5, KR2\]
+    
+      - > [*https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit*](https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit)
+    
+      - > Nicole: received good feedback on revised structure of ReadMe
+        > file. Goal is to finalize structure to put together content
+        > for new ReadMe file. By OSLS, new ReadMe file in place. 
+    
+      - > Matt: Good goal to finalize new structure regardless of
+        > content, good to share with other WGs. 
+    
+      - > Review of changes, feedback. 
+        
+          - Georg: suggest moving background section down lower, metrics
+            up top. 
+          - Nicole: suggest others share how they contribute so that
+            others will understand quickly what we are doing and how to
+            get involved. 
+          - Georg: it is important, but if you are completely metrics
+            are important. 
+          - Dawn: will metrics be confusing without a lot of context?
+            That was argument for putting it down lower. 
+          - Matt: how to get involved, showcase that as a use case and
+            then people who might not really want to get involved but
+            might want to know how to use the metrics for their own
+            project. 
+          - Sarah: trying to reach two audiences, both important. 
+          - Dawn: Ben had best practices on this. 
+          - Georg: a sentence on purpose, goals, outcomes, process, then
+            link to section below. So when you are new to ReadMe get
+            high-level view quickly.
+          - Is Comm and Contribution in the right place (lower at spot
+            13)? George that is where I expect to see them. Dawn: read
+            about goals before jumping into contributing to better
+            understand if they want to contribute. Resolved this is the
+            right place for it. 
+    
+      - > **AI Nicole:** communicate with Ben on D\&I ReadMe file and
+        > move content into these sections. 
+    
+      - > **AI Nicole:** Submit PR with new readme file and review at
+        > next meeting. 
+
+  - Determine next week’s meeting February 18:
+    
+      - > Facilitator: Daniel
+    
+      - > Notetaker: Georg
+
+  - Subdomain for metrics release (Proposal: di.chaoss.community)
+    \[Objective \#5, KR1\] 
+    
+      - > Relates to infrastructure proposal:
+        > [*https://github.com/chaoss/metrics/issues/125*](https://github.com/chaoss/metrics/issues/125)
+    
+      - > Georg: How to release metrics? Have list of released metrics
+        > on website? Something more accessible and easier to read than
+        > info. In GitHub. Manually curated list of metrics. List would
+        > link out to definitions with our pages. Make them more
+        > pleasing to eye-GitHub template that looks more like website,
+        > automatically updated. 
+    
+      - > Dawn: will we do 3 separate pages? Or a reason we wouldn’t
+        > combine? 
+    
+      - > Georg: yes because we have 3 different repos. 
+    
+      - > Dawn: any page that aggregates? 
+    
+      - > Georg: Yes. 
+    
+      - > Further discussion postponed.
+
+  - \[Objective \#5, KR1\] Advancing metrics from CHAOSScon workshop
+    
+      - > Postponed.
+
+<span id="anchor-153"></span>February 4, 2019
+
+Agenda:
+
+  - Recap of CHAOSScon Tutorial
+  - Revisit and update Goals for 2019 - feedback from CHAOSScon/FOSDEM
+  - Update on last week’s Action Items
+  - Review “Core Contributors”
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - Other...
+  - Determine next week’s meeting facilitators and notetaker 
+
+Notes:
+
+  - Participants:
+    
+      - > Ry Jones
+    
+      - > Emmanuel Amponsah
+    
+      - > Georg Link (notetaker)
+    
+      - > Sarah Conway
+    
+      - > Nicole Huesman
+    
+      - > Daniel Izquierdo (facilitator)
+    
+      - > Matt Snell
+
+  - Recap of CHAOSScon Tutorial
+    
+      - > Slides:
+        > [*https://chaoss.github.io/website/CHAOSScon/2019EU/slides/DI-tutorial.pdf*](https://chaoss.github.io/website/CHAOSScon/2019EU/slides/DI-tutorial.pdf)
+        > 
+    
+      - > One of the metrics worked on
+        
+          - Worked on Communication Inclusivity: Speaking
+          - [*https://docs.google.com/document/d/1hwtXIUAvZzpd38vFdH-iQDa95RCgFo\_2f8a6lGzTzRc/edit*](https://docs.google.com/document/d/1hwtXIUAvZzpd38vFdH-iQDa95RCgFo_2f8a6lGzTzRc/edit)
+            
+
+  - Revisit and update Goals for 2019 - feedback from CHAOSScon/FOSDEM
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/goals-2019.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/goals-2019.md)
+        > 
+    
+      - > No feedback
+    
+      - > Nicole’s comments on the goals: Nicole’s been working to have
+        > a more consistent readme file together with GMD working group.
+
+  - Update on last week’s Action Items
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - Open
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+        
+          - Synched with Ben and GMD WG
+        
+          - Requesting feedback on a Google Doc prototype:
+            
+              - > [*https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit?usp=sharing*](https://docs.google.com/document/d/1pVtYHNTwrGFV3UyiR2qBKV0MvipoEEI-fbwavSNui4Q/edit?usp=sharing)
+                > 
+        
+          - **AI All:** Weigh in on the structure by next week, using
+            comments in the Google Doc.
+        
+          - **AI Nicole:** Send email to list to ask for feedback.
+    
+      - > **AI: Georg **Add disclaimer to PR about paid / unpaid and how
+        > it’s difficult to interpret.
+        
+          - **AI Georg:** create new pull request 
+          - [*https://github.com/chaoss/wg-diversity-inclusion/pull/158*](https://github.com/chaoss/wg-diversity-inclusion/pull/158)
+            
+          - Requested feedback
+    
+      - > **AI Matt**: Look for funding for outreachy / GSoC
+        
+          - Open, currently working on it
+    
+      - > **AI Georg:** Create a pull request, ask Ben for where it
+        > should be located (related to the goals for 2019) (README?)
+        
+          - Done, waiting for feedback
+    
+      - > **AI Daniel:** Sendout agenda before meeting.
+        
+          - Done
+
+  - Review Contributors
+    
+      - > \[Sarah Conway\](https://github.com/SarahKConway)
+    
+      - > \[UTpH\]([*https://github.com/UTpH*](https://github.com/UTpH))
+    
+      - > **AI Georg:** Create a Pull Request for above
+    
+      - > **AI Daniel:** Create a pull request that add people who
+        > contributed at CHAOSScon as contributors
+
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+    
+      - > Merged \#159 - working group
+    
+      - > Waiting for feedback on \#158 - note about paid vs unpaid
+        > contributors
+
+  - Determine next week’s meeting February 11, 2019:
+    
+      - > Facilitator: Georg Link
+    
+      - > Notetaker: Sarah Conway
+
+  - Hyperledger and CHAOSS collaboration?
+    
+      - > Ry Jones is a Community Architect for Hyperledger
+    
+      - > Hyperledger wants to be a pilot for the LF to address D\&I and
+        > use the CHAOSS D\&I Metrics
+
+  - Conference submissions, waiting for decisions
+    
+      - > OSLS
+    
+      - > OSCON
+    
+      - > CubeCon
+    
+      - > New: Gracehopper; call for participation is open until March
+        > 6, 2019, 5 p.m. PT.
+
+<span id="anchor-154"></span>January 28, 2019
+
+Agenda:
+
+  - Update on last week’s Action Items
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - Other...
+  - Determine next week’s meeting facilitators and notetaker 
+
+Notes:
+
+  - Participants:
+    
+      - > Dawn Foster, Matt Germonprez, Emmanuel Amponsah, Georg Link,
+        > Sarah Conway, Daniel Izquierdo 
+
+  - Update on last week’s Action Items
+    
+      - > **AI Daniel:** Coordinate with Dawn to put together the
+        > CHAOSScon D\&I Tutorial session description. Send to Georg to
+        > put it on schedule.
+        
+          - Done
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - Open
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+        
+          - Nicole connected with Ben, work in progress
+    
+      - > **AI: Georg **Add disclaimer to PR about paid / unpaid and how
+        > it’s difficult to interpret.
+        
+          - **AI Georg:** create new pull request 
+          - Open
+    
+      - > **AI Matt**: Look for funding for outreachy / GSoC
+        
+          - Open, will happen next week
+    
+      - > **AI Georg: **Cleanup goals document. Review next week during
+        > meeting. Then pull-request.
+        
+          - Done:
+            [*\#123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+
+  - Revisit and update Goals for 2019
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+        > 
+    
+      - > Document is cleaned up.
+    
+      - > We spent the majority of the meeting going over our goals for
+        > 2019 and refining language
+    
+      - > **AI Georg:** Create a pull request, ask Ben for where it
+        > should be located (README?)
+
+  - Pull requests
+    
+      - > \# 155 - change filenames
+        
+          - Waiting for @UTpH to update links in pr
+
+  - Determine next week’s meeting February 4, 2019:
+    
+      - > Facilitator: Daniel Izquierdo
+        
+          - **AI Daniel:** Sendout agenda 24+ hours before meeting.
+    
+      - > Notetaker: Georg Link
+        
+          - **AI Georg:** Send out minutes after meeting.
+
+<span id="anchor-155"></span>January 21, 2019
+
+Agenda:
+
+  - [*D\&I Tutorial
+    content*](https://docs.google.com/presentation/d/1969aex0VZNeCcnTztYCFxG7Q98JnHV5IGtylh59a-H0)
+  - Contribution Type Metric
+    [*\#153*](https://github.com/chaoss/wg-diversity-inclusion/pull/153)
+  - Update on last week’s Action Items
+  - Outreachy project outline for recruiting funding
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - Other...
+  - Determine next week’s meeting facilitators and notetaker
+
+Notes:
+
+  - Participants:
+    
+      - > Emma Irwin
+    
+      - > Matt Germonprez
+    
+      - > Dawn Foster
+    
+      - > Daniel Izquierdo
+    
+      - > Emmanuel Amponsah
+    
+      - > Georg Link
+
+  - Update on last week’s Action Items
+    
+      - > **AI Nicole: **Nicole will submit session for OSLS, after
+        > sending to Sarah for comments
+        
+          - complete
+    
+      - > **AI Daniel:** Coordinate with Dawn to put together the
+        > CHAOSScon D\&I Tutorial session description. Send to Georg to
+        > put it on schedule.
+        
+          - Dawn will send description to Georg
+    
+      - > **AI Nicole and Sarah:** prepare a D\&I session proposal for
+        > OSCON.
+        
+          - complete
+    
+      - > **AI Georg:** Create pull request for Contribution Type metric
+        > for review phase.
+    
+      - > (previous week, did not review last week:)
+        
+          - complete
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - open
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+        
+          - open
+    
+      - > **AI: Georg **Add disclaimer to PR about paid / unpaid and how
+        > it’s difficult to interpret.
+        
+          - **AI Georg:** create new pull request
+
+  - D\&I Tutorial content:
+    
+      - > First introduction of 15 minutes + presentation, then give an
+        > overview on a couple of existing and merged questions, and
+        > finally split people in several groups and work all together
+        > in the final Google Docs so everyone can help.
+    
+      - > Concerns about how to help people to feel they’re part of this
+        > =\> there are other ways to contribute such as reviewing, etc.
+        > Be sure that we acknowledge their work.
+    
+      - > Provide some structure is needed to everything does not go
+        > wild, but too much structured might be something to avoid =\>
+        > we rely on the examples and the existing template.
+
+  - Contribution type discussion will be moved to the ‘new’ working
+    group. More on this at the Non-Verbal Updates.
+
+  - Review of the last meeting tasks (work done in the last week action
+    item).
+
+  - Outreachy and GSoC projects.
+    
+      - > Create document that pulls together metrics with examples
+    
+      - > Project to prototype ways to represent D\&I signals
+    
+      - > **AI Matt**: Look for funding
+
+  - Revisiting goals for 2019:
+    
+      - > **AI Georg: **Cleanup document. Review next week during
+        > meeting. Then pull-request.
+
+  - Emmanuel Amponsah, to meet with some people from his team at FOSDEM
+    and we’ll all try work together advancing in the D\&I.
+
+  - Determine next week’s meeting January 28, 2019:
+    
+      - > Facilitator: Sarah Conway
+    
+      - > Notetaker: Georg Link
+
+**Non-Verbal Updates**.
+
+(Emma)
+
+Sorry I can’t stay today.
+
+I wanted to circle back on the [*contribution type work from
+Georg*](https://github.com/chaoss/wg-diversity-inclusion/pull/153), and
+conversation. And I am wondering, if we’re sometimes creating metrics
+that we need, because they don’t exist in CHAOSS yet... so that we can
+then apply the d\&I lens. And this might add bloat to or repo/content.
+
+Basically, if someone new were to look across CHAOSS, for metrics that
+involve contribution would D\&I be an obvious choice? I’m not sure. 
+What I am suggesting we discuss, is how we abstract d\&I from other
+metrics. We can still build them, just deliberate about where.
+
+\*hopes this is translates, and makes sense in text\* - 
+
+Georg: Thanks Emma, I will add contribution type to our agenda
+
+<span id="anchor-156"></span>January 14, 2019
+
+Agenda:
+
+  - Update on last week’s Action Items
+
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+
+  - Agenda sent out with meeting reminder:
+    
+      - > Revisit & update goals for 2019--hold until next meeting
+    
+      - > Review open pull requests
+    
+      - > Review open action items
+    
+      - > Review roadmap of events
+    
+      - > Work on metrics
+    
+      - > CHAOSS Charter -- add ethics to charter, there’s a window to
+        > do that as the board will be updating the charter; will need
+        > to formulate/write it & create a pull request
+
+  - other...
+
+  - Determine next week’s meeting facilitators and notetaker
+
+Notes:
+
+  - Attending: Georg Link, Nicole Huesman, Daniel Izquierdo, Sarah
+    Conway
+
+  - Postponing Goals meeting until next meeting.
+
+  - OSLS abstract draft posted to list by Nicole. 
+    
+      - > **AI Nicole: **Nicole will submit session for OSLS, after
+        > sending to Sarah for comments
+
+  - CHAOSScon: D\&I Workgroup needs to put together a description of the
+    tutorial session.
+    
+      - > [*https://chaoss.community/chaosscon-2019-eu/*](https://chaoss.community/chaosscon-2019-eu/)
+    
+      - > **AI Daniel:** Coordinate with Dawn to put together the
+        > CHAOSScon D\&I Tutorial session description. Send to Georg to
+        > put it on schedule.
+
+  - OSCON (Portland in July 15-18) - deadline is tomorrow 
+    
+      - > [*https://conferences.oreilly.com/oscon/oscon-or/public/cfp/694*](https://conferences.oreilly.com/oscon/oscon-or/public/cfp/694)
+    
+      - > Reuse the OSLS proposal.
+    
+      - > **AI Nicole and Sarah:** prepare a D\&I session proposal for
+        > OSCON.
+
+  - Other events to consider?
+    
+      - > KubeCon + CloudNativeCon:
+        > [*https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/cfp/*](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/cfp/)
+    
+      - > OpenStackSummit
+
+  - Metrics working session 20 minutes
+    
+      - > Georg: Contribution Type
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/116*](https://github.com/chaoss/wg-diversity-inclusion/issues/116)
+    
+      - > Daniel: Onboarding
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+    
+      - > Nicole: Mentorship
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120)
+    
+      - > Sarah: Review and help revise metrics. 
+    
+      - > **AI Georg:** Create pull request for Contribution Type metric
+        > for review phase.
+
+  - Determine next week’s meeting January 21, 2019:
+    
+      - > Facilitator: Sarah Conway
+    
+      - > Notetaker: Nicole Huesman
+
+<span id="anchor-157"></span>January 7, 2019
+
+Agenda:
+
+  - Update on last week’s Action Items
+  - Review of core contributors
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - other...
+  - Determine next week’s meeting facilitators and notetaker
+
+Notes:
+
+  - Attending: Georg Link, Dawn Foster, Matt Germonprez, Nicole Huesman
+
+  - Action items from previous meetings, ongoing:
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - Open. Will do this after the other twol.
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+        
+          - Open. Will reach out to Ben today.
+    
+      - > **AI Nicole:** Draft a proposal for the D\&I workgroup to
+        > submit to OSLS.
+        
+          - Open. Started abstract. How much do we want to present vs.
+            interactive time to get feedback? We’ll submit it as a
+            panel.
+    
+      - > **AI Daniel:**
+        > \#[*120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120)
+        > and
+        > \#[*121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+        > 
+        
+          - Open.
+    
+      - > **AI Dawn:**
+        > \#[*118*](https://github.com/chaoss/wg-diversity-inclusion/issues/118)
+        
+          - Open - no progress yet.
+    
+      - > **AI Georg**: send old D\&I ML emails to be archived
+        
+          - Open - still in progress. Will follow up.
+    
+      - > **AI All:** As the metrics repository is going to be removed,
+        > we all should be sure that all of the existing metrics in the
+        > repository are represented in the D\&I working group (see[*
+        > issue
+        > \#143*](https://github.com/chaoss/wg-diversity-inclusion/issues/143))
+        
+          - Close this. We’re not removing this repository, so no action
+            required.
+
+  -  Review of core contributors
+    
+      - > Added: None.
+    
+      - > Remove: None.
+
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+    
+      - > **AI: Emma** to give edit rights to core contributors.
+    
+      - > Deferred to next week, until we have access to edit this
+        > document.
+
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+    
+      - > **AI: Georg** to get Nithya’s approval to add her to list of
+        > contributors.
+    
+      - > Closing organizational affiliation health pull request without
+        > merging. 
+    
+      - > **AI: Georg **Add disclaimer to PR about paid / unpaid and how
+        > it’s difficult to interpret.
+
+  - Other…
+    
+      - > nothing.
+
+  - Determine next week’s meeting January 14, 2019:
+    
+      - > Facilitator: Nicole
+    
+      - > Notetaker: Georg
+
+<span id="anchor-158"></span>December 17, 2018
+
+Agenda Proposal:
+
+  - Update on last week’s Action Items
+  - Holiday meeting schedule
+  - **Focus of Meeting: Revisit and update Goals for 2019:
+    **[*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - A message from Matt
+  - Determine next week’s meeting facilitators and notetaker
+
+Notes:
+
+  - Attending: Georg Link, Dawn Foster, Sarah Conway, Emma Irwin
+
+  - Action items from previous meetings, ongoing:
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+        
+          - open
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+        
+          - open
+    
+      - > **AI Maintainers**: put a review of core contributors on
+        > agenda once a month
+        
+          - Next meeting
+    
+      - > **AI Nicole:** Draft a proposal for the D\&I workgroup to
+        > submit to OSLS.
+        
+          - open
+    
+      - > **AI Daniel:**
+        > \#[*120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120)
+        > and
+        > \#[*121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+        > 
+        
+          - open
+    
+      - > **AI Dawn:**
+        > \#[*118*](https://github.com/chaoss/wg-diversity-inclusion/issues/118)
+        
+          - open
+    
+      - > **AI Georg:**
+        > \#[*116*](https://github.com/chaoss/wg-diversity-inclusion/issues/116)
+        
+          - In progress: ready for review
+    
+      - > **AI Georg**: send old D\&I ML emails to be archived
+        
+          - Done sending; waiting for IT to put them in the archive
+    
+      - > **AI Georg**: email D\&I list about pull request for adding
+        > org affiliations / paid / unpaid as demographics.
+        
+          - Done - had good conversation during meeting.
+    
+      - > **AI All:** As the metrics repository is going to be removed,
+        > we all should be sure that all of the existing metrics in the
+        > repository are represented in the D\&I working group (see[*
+        > issue
+        > \#143*](https://github.com/chaoss/wg-diversity-inclusion/issues/143))
+        
+          - Need to discuss more
+
+  - Cancel next two week’s meetings. Next meeting is January 7, 2019
+
+  - GOALS 2019
+    
+      - > Struck out sentences are often ‘solutions’ and do not belong
+        > to the goals and key results.
+    
+      - > We went through the goal document and revised every item.
+
+  - Message from Matt:
+    
+      - > “I won't make today's D\&I meeting. I think the biggest issue
+        > for me is to say that I'm very happy that D\&I has
+        > representation on the CHAOSS board.”
+
+  - January 7, next meeting: 
+    
+      - > Facilitator: Georg, 
+    
+      - > Notetaker: Dawn
+
+<span id="anchor-159"></span>December 10, 2018
+
+Agenda:
+
+  - Introductions
+  - Update on last week’s Action Items
+  - Go through open pull requests:
+    [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+    
+  - Propose versioning of D\&I metrics \[request from monthly CHAOSS
+    Meeting\]
+  - Revisit and update Goals for 2019:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123)
+    
+  - Go through issues on GitHub:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+  - Metrics repository, are they represented in the D\&I repo
+  - … other?
+  - Determine next week’s meeting facilitators and notetaker
+
+Notes:
+
+  - Attending: Dawn Foster, Georg Link, Sarah Conway, Daniel Izquierdo,
+    Emma 
+
+  - Action items from previous meetings, ongoing:
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+    
+      - > **AI Maintainers**: put a review of core contributors on
+        > agenda once a month
+    
+      - > **AI Nicole:** Draft a proposal for the D\&I workgroup to
+        > submit to OSLS.
+    
+      - > **AI Daniel:**
+        > \#[*120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120)
+        > and
+        > \#[*121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+        > 
+    
+      - > **AI Dawn:** \#118
+    
+      - > **AI Georg:** \#116
+
+  - New goals of the group? Best practices for D\&I from other working
+    groups, organizations, open source projects, etc.
+
+  - Reviewing last meeting actions:
+    
+      - > **AI Georg**: send old emails
+    
+      - > Actions on contributing or readme: no advances
+    
+      - > OSLS submissions: no advances
+    
+      - > Advances in some issues: 120 and 121 all related to Leadership
+        > focus area, there have not been any advances. 
+
+  - Need to decide which meetings to cancel during the holidays:
+    
+      - > **AI Dawn**: Send an email to schedule next meetings during
+        > holidays.
+
+  - Pull request adds paid contributor vs. unpaid volunteer contributor
+    and organizational affiliation to Dimensions of Demographics
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/140*](https://github.com/chaoss/wg-diversity-inclusion/pull/140)
+
+  - Discussion about having organization diversity
+    
+      - > Should organizational diversity be part of the D\&I working
+        > group? Georg had as an answer from his set of surveys that
+        > this specific point was important for D\&I.
+    
+      - > This specific point was initially not part of the D\&I as
+        > people tend to gamify this, but is it important this
+        > information? Is more healthy an OSS project lead by a company
+        > or by several companies?
+    
+      - > This is related to the discussion about paid and unpaid
+        > developers in a community.
+    
+      - > Having different companies and different commercial view
+        > points helps in the health of the community.
+    
+      - > We may need a strong rationale for this discussion as having
+        > diversity of organizations may be seen as a discussion not
+        > related to D\&I
+    
+      - > Welcoming to volunteers
+    
+      - > This discussion may be left for the general CHAOSS meetings.
+    
+      - > **AI Georg**: email D\&I list about pull request
+
+  - Metrics version discussion:
+    
+      - > How to version the existing metrics?
+    
+      - > How can we link a specific metric with a specific software
+        > release? This working group is kind of working in a continuous
+        > way.
+    
+      - > How can we see the maturity of a metric?
+    
+      - > D\&I metrics might be that they are less complex than other
+        > metrics. 
+    
+      - > There’s still a diverse set of opinions :).
+    
+      - > This discussion is related to the Objective 4 at the Goals for
+        > 2019 document:
+        > [*https://docs.google.com/document/d/1\_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit\#heading=h.o84ezb8hshgr*](https://docs.google.com/document/d/1_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit#heading=h.o84ezb8hshgr)
+    
+      - > **Proposal:** Defer to GMD for versioning procedure.
+        > Preference for periodic batch releases of all CHAOSS metrics
+        > with a change log since last release.
+
+  -  Revisit and Update goals for 2019
+    
+      - > Discussion about the document.
+    
+      - > Why do we have these goals on the table right now? Intro to
+        > CHAOSS, Emma’s work, etc.
+    
+      - > We’ll wait for Emma for further work. Willing to have this
+        > discussion during the next Monday meeting.
+
+  -  Metrics repository, are they represented in the D\&I repo
+    
+      - > [*https://github.com/chaoss/metrics/blob/master/1\_Diversity-Inclusion.md*](https://github.com/chaoss/metrics/blob/master/1_Diversity-Inclusion.md)
+        > 
+    
+      - > **AI All:** As this repository is going to be removed, we all
+        > should be sure that all of the existing metrics in the
+        > repository are represented in the D\&I working group.
+    
+      - > A way to introduce those is to have a new focus area or add
+        > metric by metric to each of the existing focus areas.
+    
+      - > **AI Georg:** create issue to keep track of this. 
+
+  -  Facilitator and notetaker:
+    
+      - > Dawn Foster as facilitator.
+    
+      - > Georg Link as notetaker.
+
+  -  
+
+  - 
+
+<span id="anchor-160"></span>December 3, 2018
+
+Agenda:
+
+  - Go through open pull requests 
+  - Mailing list does not have an archive 
+  - Revise CONTRIBUTING.md
+  - Status of the README (see
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues/127*](https://github.com/chaoss/wg-diversity-inclusion/issues/127))
+  - Discuss contributions (see
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues/126*](https://github.com/chaoss/wg-diversity-inclusion/issues/126))
+    
+  - Proposals: Python DevRoom, OSLS
+  - Rotating Meeting facilitators
+  - How do we move people into more active roles?
+  - Go though issues on GitHub:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    and summary of last actions
+  - ...
+
+Notes:
+
+  - Attending: Dawn Foster, Daniel Izquierdo, Georg Link, Matt
+    Germonprez, Nicole Huesman
+
+  - Going through pull requests:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/130*](https://github.com/chaoss/wg-diversity-inclusion/pull/130)
+        
+          - merged
+    
+      - > **Agreed: **When merging a pull request, delete branches\!
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/131*](https://github.com/chaoss/wg-diversity-inclusion/pull/131)
+        
+          - Merged
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/134*](https://github.com/chaoss/wg-diversity-inclusion/pull/134)
+        
+          - Merged
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/133*](https://github.com/chaoss/wg-diversity-inclusion/pull/133)
+        
+          - New metric: Leadership Diversity
+          - PR is to add the list to our focus area
+          - Detail Page is developed in this issue:
+            [*https://github.com/chaoss/wg-diversity-inclusion/issues/132*](https://github.com/chaoss/wg-diversity-inclusion/issues/132)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/128*](https://github.com/chaoss/wg-diversity-inclusion/pull/128)
+        
+          - Add contributor list. Merged
+
+  - Who contributed? Did we include everyone?
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion\#contributors*](https://github.com/chaoss/wg-diversity-inclusion#contributors)
+    
+      - > **AI Dawn:** Someone needs to create a PR to add Matt’s and
+        > Nicole’s github account. 
+    
+      - > Also document that Maintainers will review the list of core
+        > contributors once a month.
+
+  - Mailing list does not have an archive 
+    
+      - > **AI Matt:** Reach out to LF again
+
+  - Some issues closed:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/77*](https://github.com/chaoss/wg-diversity-inclusion/issues/77),
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/81*](https://github.com/chaoss/wg-diversity-inclusion/issues/81),
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/78*](https://github.com/chaoss/wg-diversity-inclusion/issues/78)
+        > These three tickets were already fixed. Daniel closed them.
+
+  -  Revise CONTRIBUTING.md
+    
+      - > How to create pull requests?
+    
+      - > We do have a CONTRIBUTING.md
+        
+          - [*https://github.com/chaoss/wg-diversity-inclusion/blob/master/CONTRIBUTING.md*](https://github.com/chaoss/wg-diversity-inclusion/blob/master/CONTRIBUTING.md)
+    
+      - > **AI Nicole: **Describe better how to get involved. Expand the
+        > CONTRIBUTING.md
+    
+      - > 
+
+  -  Status of the README 
+    
+      - > (see
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/127*](https://github.com/chaoss/wg-diversity-inclusion/issues/127))
+    
+      - > **AI Nicole:** Coordinate with Ben on revising the README.md
+    
+      - > Combine effort with revising the CONTRIBUTING.md
+    
+      - > 
+
+  -  Discuss contributions 
+    
+      - > (see
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/126*](https://github.com/chaoss/wg-diversity-inclusion/issues/126))
+        > 
+    
+      - > We merged the pull request[
+        > ](https://github.com/chaoss/wg-diversity-inclusion/pull/128)[*\#128*](https://github.com/chaoss/wg-diversity-inclusion/pull/128).
+    
+      - > The readme now has our current definitions.
+    
+      - > Is there any more need for discussion?
+    
+      - > Are there other things we can do to highlight (track)
+        > contributions?
+    
+      - > **AI Maintainers**: put a review of core contributors on
+        > agenda once a month
+
+  - Proposals: Python DevRoom, OSLS
+    
+      - > Daniel submitted to Python DevRoom 
+    
+      - > Open Source Leadership Summit CFP opens now, closes Jan 28,
+        > 2019
+        
+          - [*https://events.linuxfoundation.org/events/open-source-leadership-summit-2019/program/cfp/*](https://events.linuxfoundation.org/events/open-source-leadership-summit-2019/program/cfp/)
+            
+          - Strategic focused session
+          - Goal to contact community leaders who have an interest in
+            implementing our work
+          - In advance: Prepare our work to be consumable
+          - Also get feedback on our work.
+          - **AI Nicole:** Draft a proposal for the D\&I workgroup.
+
+  - D\&I representation on Governing Board
+    
+      - > Dawn and Georg expressed interest
+
+  - Rotating Meeting facilitators
+    
+      - > **Agreed: **We want to rotate.
+    
+      - > Proposal: At end of meeting, determine who is facilitating
+        > next week, will update agenda, and send out reminder.
+    
+      - > Also determine who is responsible for note taking (not same
+        > person)
+
+  - How do we move people into more active roles?
+    
+      - > D\&I and GMD (tagged on to contributors and maintainers)
+    
+      - > Tag issues as ‘good first issue’ or ‘easy bugs’ - send
+        > reminder on mailing list that there are easy ways to
+        > contribute (once a month?) - maybe a blog post that can be
+        > sent out to Twitter or LinkedIn
+    
+      - > Send meeting minutes to the CHAOSS list and include at the end
+        > of every meeting minutes 1 or 2 easy issues we would like help
+        > with.
+
+  -  Go though issues on GitHub:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    and summary of last actions
+    
+      - > Please review issues with “ready for review” so that we can
+        > move them to pull requests
+    
+      - > **AI Daniel:**
+        > \#[*120*](https://github.com/chaoss/wg-diversity-inclusion/issues/120)
+        > and
+        > \#[*121*](https://github.com/chaoss/wg-diversity-inclusion/issues/121)
+        > 
+
+  - Meeting End 
+
+The D\&I workgroup would appreciate help with the following “good first
+issues”:
+
+  - File Naming Standard:
+    https://github.com/chaoss/wg-diversity-inclusion/issues/101 
+
+<span id="anchor-161"></span>November 26, 2018
+
+Agenda:
+
+  - Finalize FOSDEM proposals (Python devroom - Daniel)
+
+  - Emma’s Document
+    ([*https://github.com/chaoss/wg-diversity-inclusion/issues/123*](https://github.com/chaoss/wg-diversity-inclusion/issues/123))
+    AND/OR 
+    
+      - > WE ARE NOW HERE:
+        > [*https://docs.google.com/document/d/1\_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit\#heading=h.afrr9xwu1zby*](https://docs.google.com/document/d/1_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit#heading=h.afrr9xwu1zby)
+
+  - DEFER: Discuss Open Canvas until we have more clear objectives
+    
+      - > [*~~https://docs.google.com/presentation/d/1pgBh3T\_CWZR54xRTPCxl5F0S-PR2mhh4QbwXYahdw9A/edit?usp=sharing~~*](https://docs.google.com/presentation/d/1pgBh3T_CWZR54xRTPCxl5F0S-PR2mhh4QbwXYahdw9A/edit?usp=sharing)
+    
+      - > ~~Background information on the open canvas:
+        > ~~[*~~https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/~~*](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/)
+
+  - Resource Pages that Daniel had worked on, which might be done and
+    need merging
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/77*](https://github.com/chaoss/wg-diversity-inclusion/issues/77)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/78*](https://github.com/chaoss/wg-diversity-inclusion/issues/78)
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/issues/81*](https://github.com/chaoss/wg-diversity-inclusion/issues/81)
+        > 
+
+  - Go though issues on GitHub:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    and summary of last actions
+
+  - Add new maintainers:
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pulls*](https://github.com/chaoss/wg-diversity-inclusion/pulls)
+        > 
+
+  - 24 Pull Requests / Contributions project
+
+Notes:
+
+  - Attending: Georg Link, Dawn Foster, Daniel Izquierdo, Matt
+    Germonprez, Nicole Huesman, Emma Irwin
+
+  - Talk submissions
+    
+      - > FOSDEM Python DevRoom proposal - Daniel will send Dawn and
+        > Emma the materials so that we can decide who to put as the
+        > co-presenter. 
+    
+      - > Dawn will submit the Panel to CHAOSScon right after the
+        > meeting
+    
+      - > Daniel submitted the Tutorial to CHAOSScon
+
+  - Workgroup Objectives
+    
+      - > Emma introduces us to a document she created to facilitate the
+        > discussion: 
+        
+          - [*https://docs.google.com/document/d/1\_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit\#*](https://docs.google.com/document/d/1_rwp6f0teAyXZFkJien7nsmV2FankZDhLk9UmrT48vw/edit#)
+    
+      - > Emma will drive and everyone will comment and add to broken
+        > out step-by-step objectives and key results for 2019. 
+
+  - Daniel will create pull requests for the three metrics he finished
+
+  - Work on metrics:
+    
+      - > **AI:** Georg will work on Contribution-Type until next week.
+    
+      - > 
+
+  -  24 Pull Requests/Contributions
+    
+      - > Great to see that another project is using our work
+    
+      - > Emma met with Andrew and asked about asking a code-of-conduct
+        > checklist
+    
+      - > Andrew needs good examples for first (non-tech) contributions
+        > related to D\&I
+    
+      - > **AI:** Emma will share with all of us a draft
+
+<span id="anchor-162"></span>November 19, 2018
+
+Video recording:
+[*https://youtu.be/KJ5SZPZaZvY*](https://urldefense.proofpoint.com/v2/url?u=https-3A__youtu.be_KJ5SZPZaZvY&d=DwMFaQ&c=Cu5g146wZdoqVuKpTNsYHeFX_rg6kWhlkLF8Eft-wwo&r=P2SSJg6nDRqSw6MK6ZVW76NaDtv69G3wvyOnOxwzqv0&m=7WLNTKfE2Nv5XGc1cyJ6iOETW23JXGXVj23CAu6Im1g&s=MlCAjUn62JdSV3Jd5rBi3r65Mkb2jCHbXWjQannXeYA&e=)
+
+Agenda:
+
+  - D\&I representation Governing Board 
+
+  - Discuss Emma’s involvement in CHAOSS D\&I.
+
+  - Decide on D\&I proposals for FOSDEM Community devroom (due 23rd) &
+    CHAOSSCon (due 26th).
+    
+      - > CHAOSSCon D\&I Panel Proposal:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/107*](https://github.com/chaoss/wg-diversity-inclusion/issues/107)
+    
+      - > D\&I Tutorial proposal for CHAOSSCon:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/108*](https://github.com/chaoss/wg-diversity-inclusion/issues/108)
+
+  - Discuss Open Canvas
+    
+      - > [*https://docs.google.com/presentation/d/1pgBh3T\_CWZR54xRTPCxl5F0S-PR2mhh4QbwXYahdw9A/edit?usp=sharing*](https://docs.google.com/presentation/d/1pgBh3T_CWZR54xRTPCxl5F0S-PR2mhh4QbwXYahdw9A/edit?usp=sharing)
+    
+      - > Background information on the open canvas:
+        > [*https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/*](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/)
+
+  - Switch to Discourse for the D\&I workgroup?
+    
+      - > [*https://discourse.chaoss.community/*](https://discourse.chaoss.community/)
+        > 
+    
+      - > Our email archive is empty:
+        > [*https://lists.linuxfoundation.org/pipermail/chaoss-diversity-inclusion/*](https://lists.linuxfoundation.org/pipermail/chaoss-diversity-inclusion/)
+
+  - Georg’s Interviews
+    
+      - > New page: Leadership: Sponsorship
+        > [*https://docs.google.com/document/d/1J-9f\_wYQxP26L\_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit*](https://docs.google.com/document/d/1J-9f_wYQxP26L_bF7JpS7Xez18cdM4WsKuw0UpBgVfU/edit)
+        > 
+
+  - Resource Pages that Daniel had worked on, which might be done and
+    need merging
+
+  - Go though issues on GitHub:
+    [*https://github.com/chaoss/wg-diversity-inclusion/issues*](https://github.com/chaoss/wg-diversity-inclusion/issues)
+    
+
+Action Items:
+
+  -  Matt: send an email to the mailing list asking for nominations for
+    Governing Board.
+  -  
+  -  
+
+Notes:
+
+  - Attendees: Matt Germonprez, Dawn Foster, Georg Link, Emma Irwin,
+    Daniel Izquierdo
+
+  - Upcoming Governing Board Meeting
+    
+      - > It would be nice to have D\&I representation on the board.
+        > (Self-)Nominations? 
+    
+      - > Matt will send an email to the mailing list asking for
+        > nominations.
+
+  - Missing Archive / Discourse
+    
+      - > Request archive from LF IT support
+    
+      - > Stay with mailing list, do not use Discourse
+
+  - Emma’s involvement in CHAOSS D\&I
+    
+      - > Work will include using metrics, but not time to drive the
+        > project
+    
+      - > Maybe spend remaining time this year to 
+
+  - How do we measure success of the D\&I workgroup
+    
+      - > Maybe a whitepaper?
+    
+      - > Governing Board involvement (both ways)
+    
+      - > How do we engage new people?
+    
+      - > Could the LF have a paid person to full time support the
+        > CHAOSS effort?
+    
+      - > Decide what is the goal and once we reach it disband the
+        > workgroup?
+    
+      - > CHAOSS fosters a conversation. 
+    
+      - > Written sharing of our knowledge generated. 
+    
+      - > Maybe have some user stories. Inspiring other people and
+        > sharing.
+    
+      - > Expectation setting? - Tell me what metric, tell me what
+        > button, tell me what to look for. -- Decisions around metrics
+        > is very localized and CHAOSS cannot capture that.
+    
+      - > 
+
+  - Conference session proposal
+    
+      - > Panel and Tutorial are good to submit
+    
+      - > Possibly have a Python focused D\&I talk in the FOSDEM python
+        > dev room. 
+
+  -  
+
+  -  
+
+  -  
+
+  - 
+
+<span id="anchor-163"></span>November 11, 2018
+
+Agenda:
+
+  - Review and Discuss Upcoming Conference Submission Proposals:
+    
+      - > CHAOSSCon D\&I Panel Proposal:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/107*](https://github.com/chaoss/wg-diversity-inclusion/issues/107)
+    
+      - > D\&I Tutorial proposal for CHAOSSCon:
+        > [*https://github.com/chaoss/wg-diversity-inclusion/issues/108*](https://github.com/chaoss/wg-diversity-inclusion/issues/108)
+    
+      - > Discourse
+    
+      - > Others?
+
+  - Discuss next categories to tackle
+
+Action Items:
+
+  - **Everyone** - review these 2 proposals
+  - **Daniel:** write up the work session proposal
+  - **Dawn and Emma:** Think about what to do for FOSDEM Community room.
+  - Nicole - what is your GitHub handle so that we can tag you in issues
+    to look at (like the one above).
+  - **Georg:** Create new issues with google docs for remaining metrics
+    **(complete)**
+
+Notes:
+
+  - Attendees: Dawn and Georg.
+  - Both of these proposals look good, but we need more people reviewing
+    them.
+  - Reviewed action items and updated the list above
+  - Discourse. Avoid fragmentation by getting rid of email list :-)
+  - 
+
+<span id="anchor-164"></span>November 5, 2018
+
+Video recording:
+[*https://youtu.be/j3vsFoITEms*](https://urldefense.proofpoint.com/v2/url?u=https-3A__youtu.be_j3vsFoITEms&d=DwMFaQ&c=Cu5g146wZdoqVuKpTNsYHeFX_rg6kWhlkLF8Eft-wwo&r=P2SSJg6nDRqSw6MK6ZVW76NaDtv69G3wvyOnOxwzqv0&m=cJTtESLaYz0FjY4UM-4AJaeBS1D48gZpur2WZLKziDA&s=9D8cx9GaliL7L4UW5OZrOwPzA6vO_lMSQOqeUoOmfAg&e=)
+
+Agenda:
+
+\- recap OSSEU tutorial (-)
+
+\- upcoming events
+
+\- find a different time for weekly meetings
+
+\- continue work on metrics
+
+OSS Europe:
+
+  - Session well received
+  - Format & structure validated
+  - Collecting data, storing, managing, reporting -- make sure it’s
+    anonymous -- issues that were mentioned are the same we’ve talked
+    about
+
+Upcoming event:
+
+  - OpenStack Summit panel about mentorship -- panel focuses on
+    importance of mentors & mentorship programs; opportunity to
+    highlight the work we’re doing through the CHAOSS Project, might
+    bring up CHAOSS work 
+
+  - Next OpenStack Gender report might be structured according to CHAOSS
+    focus areas
+
+  - Ideas for 2019 Open Source Summits: measuring/metrics for diversity
+    & inclusion 
+
+  - CHAOSScon? February 1. Panel? Tutorial? Submit both a tutorial & a
+    panel
+    
+      - > Idea: have a working session with everyone
+    
+      - > \- make one poster for each of focus areas, maybe include
+        > dashboard displays
+    
+      - > \- participants get postit’s and leave feedback
+    
+      - > \- outcome: more buy-in, ownership, sense of contributing,
+        > drive adoption
+    
+      - > \- ask everyone to post an issue? Or pull requests? Or other
+        > low-hanging fruits
+    
+      - > Checklist example:
+        > [*https://github.com/mozilla/diversity/blob/master/evaluation\_tools/governance-basic.md*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/governance-basic.md)
+
+  - **AI Daniel:** write up the work session proposal
+
+  - **AI Dawn**: write up a proposal for panel
+
+  - **AI Georg:** write up a proposal for tutorial
+
+  - Emma @Drupalcon will be talking about D\&I Metrics (seattle in
+    April)
+
+  - FOSDEM Community DevRoom: Submission due 11/23: 
+    
+      - > Is there a collaborative format for getting input from
+        > audience - not good for FOSDEM format
+    
+      - > Maybe a talk
+    
+      - > Going: Emma, Daniel, Dawn
+    
+      - > [*https://medium.com/@leslielauralive/fosdem-2019-community-dev-room-cfp-f60bdc067c22*](https://medium.com/@leslielauralive/fosdem-2019-community-dev-room-cfp-f60bdc067c22)
+    
+      - > **AI Dawn and Emma:** Think about what to do
+
+  -  
+
+  -  Find new times:
+    
+      - > Mondays at 9:30am US Central time
+
+  -  How to advance metrics:
+    
+      - > For new metrics, we start a google doc
+    
+      - > If we want to get started on a new metric, create new issues
+        > and link to a google doc.
+    
+      - > **AI Georg:** Setup issues and google docs.
+
+  - Strategy for citations and research that backs up documents
+    
+      - > Capture that the page is derived from our experiences
+    
+      - > Maybe cite some conferences that already used the metrics or
+        > methods
+
+  - FYI Emma updated how she talks about [*CHAOSS WG organization of
+    process and
+    design.*](https://docs.google.com/presentation/d/1yBX0vhY2KJhL3iwnZL4xN_Af05Ki0xqMJOx2Ez297Pk/edit#slide=id.g44ad3105be_0_0)
+    
+      - > Georg edited slide 5:
+        > [*https://docs.google.com/presentation/d/1vaZlcg\_HfUNY-BkdyGmzpDeO5EHPIKPO0hVppailShA/edit\#slide=id.g44ad3105be\_0\_0*](https://docs.google.com/presentation/d/1vaZlcg_HfUNY-BkdyGmzpDeO5EHPIKPO0hVppailShA/edit#slide=id.g44ad3105be_0_0)
+        > 
+
+  - **AI Nicole:** Review Readme file for clarity and newcomer
+    friendlyness.
+
+  - **AI Nicole:** Twitter promote conference tweets on our @chaossproj
+    channel and 
+
+<span id="anchor-165"></span>Oct 17, 2018
+
+\- AI Georg: look for CHAOSS related Summit Talks
+
+\- AI Georg: create pr with template -- complete
+
+\- AI Georg: pr to remove authors -- complete
+
+\- AI Georg: pr to remove zero -- complete
+
+\- AI Dawn: pr for event sections
+
+\- AI Daniel: pr for governance
+
+\- AI Emma: pr with code of conduct page
+
+\- AI Nicole: twitter promotions
+
+\- AI Nicole: readme
+
+Zoom Chat:
+
+*From Me (Georg) to Everyone: 06:10 PM*
+
+Planning Doc for Tutorial:
+https://docs.google.com/document/d/1r8NjAiqSIo5\_H0T1vYjUh\_BGzDQLrR7u05v1Aqrmrb0/edit\#heading=h.m3t7pu27euxt
+
+*From Me to Everyone: 06:17 PM*
+
+@Sean, we are working on these slides right now:
+https://docs.google.com/presentation/d/1lSmHVgvZe6NN6FHqKXzz6pQEf3qXYR968nc8X0\_UfrA/edit\#slide=id.g42b47b4820\_0\_81
+
+*From Sean Goggins to Everyone: 06:21 PM*
+
+You could do a custom shortened link that’s meaningful … I think bit.ly
+lets you do that .. .and goo.gl as well might
+
+I just made this one for my personal website publication list, for
+example: http://bit.ly/Sean-Goggins-Pubs
+
+*From Me to Everyone: 06:36 PM*
+
+Template:
+https://github.com/chaoss/wg-diversity-inclusion/blob/master/templates/focus\_area.md
+
+@Emma, thoughts on slide 5 (About Us):
+https://docs.google.com/presentation/d/1lSmHVgvZe6NN6FHqKXzz6pQEf3qXYR968nc8X0\_UfrA/edit\#slide=id.g45070d4d76\_0\_0
+
+*From Emma Irwin to Everyone: 06:38 PM*
+
+https://github.com/chaoss/metrics
+
+*From Me to Everyone: 06:59 PM*
+
+https://help.github.com/articles/closing-issues-using-keywords/
+
+Agenda** Oct 15, 2018**
+
+Attendance:
+
+Georg, Dawn, Saloni, Nicole, Daniel, Alexander
+
+Team is focused on advancing the content for specific focus areas in
+advance of Open Source Summit Europe, to be used within the *Tutorial:
+How to Prepare a Diversity & Inclusion Report for Your Community*
+session
+
+  - Review WIP to date (e.g. Event Diversity, Governance, Code of
+    Conduct & Enforcement, Leadership, and tbd areas from Nicole)
+  - Discuss collaboration options for discussions.
+
+Emma is also leading two sessions and will mention CHAOSS work. Sorry I
+haven’t shared that yet, because I am behind making slides :S
+
+  - Inclusive Open Governance, What are you Waiting for
+  - Metrics that Matter for Diversity & Inclusion
+
+Emma was also invited to speak at Drupalcon in April , and will make
+CHAOSS/metric central part of story I share for ‘What Matters for
+Inclusion, Matters for Product Innovation’, if someone else wants to
+co-submit a proposal for Drupalcon as an actual session, I am sure there
+would be interest.
+
+MOSS (Mozilla’s grant program) will be using this[* initial
+checklist*](https://github.com/mozilla/diversity/blob/master/evaluation_tools/governance-basic.md),
+based on our work. Asking applicants to review as part of applying.
+
+Move to markdown files the existing work in the Google Docs (add
+disclaimer about how complete they are or they are not).
+
+Tweets: share slides with Nicole, she will tweet about this.
+
+Next Meeting (any before the Tutorial?)
+
+Related Links:
+
+Links to documents we talked about.
+
+  - Tutorial Planning Doc
+    [*https://docs.google.com/document/d/1r8NjAiqSIo5\_H0T1vYjUh\_BGzDQLrR7u05v1Aqrmrb0/edit\#heading=h.m3t7pu27euxt*](https://docs.google.com/document/d/1r8NjAiqSIo5_H0T1vYjUh_BGzDQLrR7u05v1Aqrmrb0/edit#heading=h.m3t7pu27euxt)
+  - Tutorial Slides:
+    [*https://docs.google.com/presentation/d/1lSmHVgvZe6NN6FHqKXzz6pQEf3qXYR968nc8X0\_UfrA/edit\#slide=id.p3*](https://docs.google.com/presentation/d/1lSmHVgvZe6NN6FHqKXzz6pQEf3qXYR968nc8X0_UfrA/edit#slide=id.p3)
+    
+
+Notes:
+
+  - 
+
+\*\*\*
+
+Agenda Oct 8, 2018
+
+Attendance: 
+
+Dawn, Daniel, Nicole
+
+Notes:
+
+  - Since there was light attendance and not much new work to review, we
+    focused on building the agenda for the meeting next week. 
+  - Note: Position OSSEU as guidance/considerations, rather than a
+    mandate
+  - Other upcoming events
+
+<!-- end list -->
+
+  - > CHAOSSCon (Feb 1) -- CFP opened, so any amplification would be
+    > great 
+
+  - > FOSDEM (Feb 2-3) -- discussed possibility of submissions,
+    > potential lack of interest among organizers for , wait to submit
+    > to Community devroom or other relevant devrooms. 
+
+Actions:
+
+  - Nicole to distribute meeting reminders on Fridays
+  - All: Team to comment on these areas for review in next week’s
+    meeting
+  - Nicole to write blog about CHAOSSCon Vancouver to promote CHAOSSCon
+    Brussels
+
+Agenda Oct 3, 2018
+
+Attendance:
+
+Georg, Emma, Nicole, Matt, Dawn, Scott Lamons, gelliott, sharan 
+
+Shoutouts:  Nicole for organizing our call, and minutes\!
+
+  - Open PRs
+    
+      - > [*https://github.com/chaoss/wg-diversity-inclusion/pull/89*](https://github.com/chaoss/wg-diversity-inclusion/pull/89)
+        
+          - Is CHAOSS going to be opinionated about how our work is used
+            ?
+          - Solution: don’t call it a ‘process’ but call it
+            “considerations”
+          - AI: Georg will update the upll request
+
+  - OSS Talks
+    
+      - > Survey
+    
+      - > Data & Metrics
+    
+      - > Open Governance
+
+  - Open Tasks
+
+  - Best strategies to connect existing work ?
+    
+      - > Inclusivity Bugs
+        
+          - Contributor Testing
+          - Leadership Standards
+    
+      - > Code of Conduct
+        
+          - Code of Conduct Assessment Tool (Emma)
+
+**Action Item**.
+
+  - Update PR 89 to be in a Resources folder
+
+  - Create README in Resources folder that describes how to find
+    resources
+    
+      - > In Focus area directories
+    
+      - > Within this directory
+    
+      - > External links compiled in a separate file within this
+        > directory.
+    
+      - > Criteria for adding a new resource…. (we want to keep high
+        > quality (have an opinion) on what can be added)
+
+  - Based on Dawn’s review of event diversity, we need to answer this
+    question:
+    
+      - > Is “ Sample Success Metrics” the right title, if we are
+        > leaning towards this section as being about methods?
+
+  - Let’s agree on what should go under the ‘Resources’ list(s), and the
+    level of quality we want from that list so as to ensure it’s highly
+    valuable, and relevant to the goals for that area.
+    
+      - > And a process for adding - that puts burden of resource
+        > exploration on the person proposing it.
+
+  - Question: how do we approach overlap between focus areas?
+
+  - Emma working on Code of Conduct, Code of Conduct Enforcement, and
+    Leadership to finish by EOD on Oct 12th.
+
+  - Nicole to sign up to complete a few areas (indicate by Monday)


### PR DESCRIPTION
This commit is the first in a series of changes to document our
extensive meeting minute history from Google Docs into GitHub. It adds
the raw meeting minutes exported from Google Doc into Markdown, and it
also separates out a section of those minutes that were not attached to
a specific date.

I did not do a lot of cleaning and polishing on the founding notes. It
is a LOT of content! It could be a good thing for someone to do in the
future, but in the interest of getting the other meeting minutes content
into GitHub, I decided I was going to use this as it was directly
exported by `pandoc`.

Future Pull Requests will break the meeting minutes out into individual
years.