### PR TITLE
:memo: minutes: Add placeholders for 2019, 2020, and 2021 minutes

### DIFF
--- a/meetings/2019.md
+++ b/meetings/2019.md
@@ -1,0 +1,9 @@
+# 2019 Meeting Minutes — CHAOSS D.E.I. Working Group
+
+This page documents all meeting minutes for the CHAOSS Diversity, Equity, & Inclusion group across 2019.
+Meeting notes were sourced from our collaborative Google Doc and moved here to improve performance issues when working in the document.
+All meetings are organized chronologically from later in the year to the beginning of the year.
+
+---
+
+## 

--- a/meetings/2020.md
+++ b/meetings/2020.md
@@ -1,0 +1,9 @@
+# 2020 Meeting Minutes — CHAOSS D.E.I. Working Group
+
+This page documents all meeting minutes for the CHAOSS Diversity, Equity, & Inclusion group across 2020.
+Meeting notes were sourced from our collaborative Google Doc and moved here to improve performance issues when working in the document.
+All meetings are organized chronologically from later in the year to the beginning of the year.
+
+---
+
+## 

--- a/meetings/2021.md
+++ b/meetings/2021.md
@@ -1,0 +1,9 @@
+# 2021 Meeting Minutes — CHAOSS D.E.I. Working Group
+
+This page documents all meeting minutes for the CHAOSS Diversity, Equity, & Inclusion group across 2021.
+Meeting notes were sourced from our collaborative Google Doc and moved here to improve performance issues when working in the document.
+All meetings are organized chronologically from later in the year to the beginning of the year.
+
+---
+
+## 


### PR DESCRIPTION
This commit mirrors the structure for the 2018 meeting minutes in Pull
Request #391. For now, the files are empty, but these placeholders give
some intention to move the meeting minutes from the raw dump and also
allows anyone else to work on slowly chipping away on moving the meeting
minutes over.