### PR TITLE
Adding Equity and Trust Metric (starter)

### DIFF
--- a/focus-areas/governance/equity-trust.md
+++ b/focus-areas/governance/equity-trust.md
@@ -1,0 +1,22 @@
+# Description
+
+Having standards and process for inclusion are a critical part of moving towards the equitable future and that inclusion is the process to get us there. The Code of Conduct is one standard, or rather a foundational standard, with things like etiquette guidelines and decision-making documents all interrelated.  This is just a beginning attempt to capture this metric.
+
+Suggested watching around this topic [Anti-Oppression Frameworks in Open Source](https://www.youtube.com/watch?v=O84XFljeYsA)
+
+# Objectives
+
+- Understand whether or not a project is setup for inclusive governance, this means that:
+- - There is a publicly facing document that describes how decisions work, the consultation process and final decision makers.
+- - Decisions, including those about funding, leadership and governance are publically accessible.
+
+NOTE: due to the potential threat to someone's privacy, and security CoC reports may not specifically fall under the category of disclosure, but WHO has the authority to make those decisions, and who is consulted should be.
+
+
+# Implementation
+
+# Tools
+
+# Data Collection Strategies
+
+


### PR DESCRIPTION
Added equity-trust as a metric under governance, as emerging knowledgeis that this is foundational for evaluating the impact of inclusive governance overall.

It's also something we will need for sustainability metrics model.