### PR TITLE
:new: :page_facing_up: Add GitHub issue templates (closes #397)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-new-metric.md
+++ b/.github/ISSUE_TEMPLATE/01-new-metric.md
@@ -1,0 +1,38 @@
+---
+name: New metric
+about: Have an idea for a new metric in the DEI Working Group? Use this template to pitch your idea.
+labels: ['metric idea', 'T: new change', '?: needs triage']
+assignees: ElizabethN, germonprez, jwflory, Nebrethar
+
+---
+
+<!-- Thank you for sharing your metric idea with the CHAOSS DEI Working Group! Please use this template to propose your metric idea. This helps our small team of reviewers collect important info about your idea and work on a quicker response to your idea. We are a small team, so please be patient if you don't hear back right away. -->
+
+# Metric basics
+<!-- Some basic details about your metric idea. -->
+
+* **Metric title**:
+* **Metric summary** (1-2 sentences):
+* **Why should this metric be created?** (1-2 sentences):
+
+
+# Data collection and measurement
+<!-- Questions to help us think about ways to collect data and how to measure your proposed metric. -->
+
+**Are there existing tools that could collect this data?** If yes, list them:
+
+**If this metric involves a lot of raw data, what filters would you use to narrow down the metric?** If applicable, describe ways to filter the data into smaller segments:
+
+**How would you visualize this metric?** If you have an idea on how this metric should be visualized or displayed so it makes the most sense to a viewer, describe that here:
+
+
+# About you
+<!-- Questions to help us understand your motive and interest in seeing this metric implemented. -->
+
+* **Are you interested in authoring this metric together with the Working Group?**: yes|no
+* **Have you attended a CHAOSS DEI Working Group meeting before?**: yes|no
+* **If not, would you consider joining one to discuss your metric idea?**: yes|no
+* **Anything else you would like us to know?**:
+
+
+

--- a/.github/ISSUE_TEMPLATE/02-misc.md
+++ b/.github/ISSUE_TEMPLATE/02-misc.md
@@ -1,0 +1,25 @@
+---
+name: Other feedback
+about: Use this template for any other non-metric idea, feedback, or task for the CHAOSS DEI Working Group.
+labels: '?: needs triage'
+assignees: ''
+
+---
+
+# Summary
+<!-- Describe the idea or task in one sentence. -->
+
+
+# Background
+<!-- Share context to why this idea or task is important and why it should be done. -->
+
+
+# Details
+<!-- Help us understand the implementation. Add specific details about the idea or task below. Are there specific next steps to take? -->
+
+
+# Outcome
+<!-- Describe the impact of completing this task or idea in one sentence. -->
+
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: CHAOSS Slack
+    url: https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g
+    about: Join the official CHAOSS Slack to meet the community and ask any questions you may have.
+  - name: Learn more about contributing
+    url: https://chaoss.community/blog-post/2021/10/13/learn-more/
+    about: Check out this blog post to get more information about participating with CHAOSS.


### PR DESCRIPTION
This commit configures issue templates for the CHAOSS DEI Working Group.
It includes two issue templates and a configuration file that references
out to the CHAOSS Slack and a blog post on how to get involved.

The issue templates are described as follows:

* **New metric**: A template for proposing a new metric to the DEI WG.
  This used the official metrics template (below) as a model to ask for
  information we use in the drafting process for a metric. Asking this
  up front should help streamline new metric ideas and make it easier to
  review them.
* **Miscellaneous**: A generic template for all other things. This uses
  a S.B.D.O. model to help someone frame their idea, task, or feedback
  into an actionable format. This template acts as a catch-all for all
  things that are not metric ideas.

Going forward, these templates can be modified and new ones can be added
based on need. This is one additional way to improve inclusion in the
working group by reducing barrier of entry for new contributors. The
template helps a new contributor (and even seasoned ones) frame their
ideas and metrics in a way that the Working Group can easily follow.

Closes #397.

ref: https://github.com/chaoss/metrics/blob/main/resources/metrics-template.md