### PR TITLE
Revised Metric: Time Inclusion for Virtual Events changes

### DIFF
--- a/focus-areas/event-diversity/README.md
+++ b/focus-areas/event-diversity/README.md
@@ -10,6 +10,6 @@ Name | Question
 [Diversity Access Tickets](diversity-access-tickets.md) | How are Diversity Access Tickets used to support diversity and inclusion for an event?
 [Code of Conduct at Event](event-code-of-conduct.md) | How does the Code of Conduct for events support diversity and inclusion?
 [Family Friendliness](family-friendly.md) | How does enabling families to attend together support diversity and inclusion of the event?
-[Inclusive Experience at Event](time-inclusion-for-virtual-events.md) | To what extent does an event organizing team commit to an inclusive experience at an event?
-[Time Inclusion](time-inclusion.md) | How can organizers of virtual events be mindful of attendees and speakers in other time zones?
+[Inclusive Experience at Event](inclusive-experience.md) | To what extent does an event organizing team commit to an inclusive experience at an event?
+[Time Inclusion for Virtual Events](time-inclusion-for-virtual-events.md) | How can organizers of virtual events be mindful of attendees and speakers in other time zones?
 [Event Accessibility](event-accessibility.md) | To what extent does your event accommodate those with various accessibility needs?

--- a/focus-areas/event-diversity/README.md
+++ b/focus-areas/event-diversity/README.md
@@ -10,6 +10,6 @@ Name | Question
 [Diversity Access Tickets](diversity-access-tickets.md) | How are Diversity Access Tickets used to support diversity and inclusion for an event?
 [Code of Conduct at Event](event-code-of-conduct.md) | How does the Code of Conduct for events support diversity and inclusion?
 [Family Friendliness](family-friendly.md) | How does enabling families to attend together support diversity and inclusion of the event?
-[Inclusive Experience at Event](inclusive-experience.md) | To what extent does an event organizing team commit to an inclusive experience at an event?
+[Inclusive Experience at Event](time-inclusion-for-virtual-events.md) | To what extent does an event organizing team commit to an inclusive experience at an event?
 [Time Inclusion](time-inclusion.md) | How can organizers of virtual events be mindful of attendees and speakers in other time zones?
 [Event Accessibility](event-accessibility.md) | To what extent does your event accommodate those with various accessibility needs?

--- a/focus-areas/event-diversity/time-inclusion-for-virtual-events.md
+++ b/focus-areas/event-diversity/time-inclusion-for-virtual-events.md
@@ -4,7 +4,7 @@ Question: How can organizers of virtual events be mindful of attendees and speak
 
 ## Description
 
-Global accessibility is vital due to the role it brings in choosing when an event should take place. Time Inclusion for Virtual Events ensures support for participation from a global community during an event. Through this metric, we are able to be more inclusive to attendees and speakers in all regions of the world. 
+Global accessibility is vital due to the role it brings in choosing when an event should take place. Time Inclusion for Virtual Events ensures support for participation from different timezones during an event. For virtual events it is impossible to schedule live presentations that are equally inclusive to all attendees and speakers from different timezones. Time inclusion for virtual events is accomplished by providing attendees and speakers inclusive ways to participate virtually in a synchronous way (e.g., in real time) while also providing methods for presenting, viewing, and taking part in event discussions asynchronously. A primary consideration for time inclusion for virtual events is the network bandwidth required to host and stream the virtual event and the network bandwidth required for virtual attendees and speakers to take part in the event. Due to inequities in the availibilty of high speed internet globally (e.g., the "Digital Divide"), time inclusion for events should include considerations for low network bandwidth options (i.e., pre-recorded presentations, chat platforms, audio only options, and availability of presentation slides for download) 
 
 ## Objectives
  Global accessibility should be understood when creating a virtual event in order to allow attendees and speakers in all regions to benefit from the event. The goal of this metric is to help organizers of virtual events develop a reasonable method to ensure those in different time zones feel included.
@@ -25,11 +25,12 @@ Survey attendees with Likert Scale [1-x] (Or Emoji Scale):
 - The event keeps time zone differences in mind
 - The event caters to my needs related to differences in time
 - The event provides adequate recordings of the talks I care about
-- I was provided with adequate low-bandwidth options at the event
+- I was provided with adequate low-bandwidth options for viewing presentations at the event
 
 Survey speakers with Likert Scale [1-x] (Or Emoji Scale):
 - The time block selected for my presentation at the event is fair to me
-- I have, or will receive, a recording of my presentation for later viewing
+- My presentation was recorded and easily accessible for later viewing by virtual attendees
+- I was provided with adequate low-bandwith options for presenting at the event
 
 ## References
 - [How To Make Virtual Meetings & Events More Inclusive](https://coonoor.medium.com/how-to-make-virtual-meetings-events-more-inclusive-de742ec0e672)
@@ -42,5 +43,7 @@ Survey speakers with Likert Scale [1-x] (Or Emoji Scale):
 - Matt Cantu
 - Lauren Phipps
 - Yehui Wang
+- Tejas Mate
+- Kevin Lumbard
 
-***This metric was last reviewed on March 08, 2022 as part of 2022-04 release.***
+***This metric was last reviewed on May 22nd, 2022 as part of the metrics revision process.***

--- a/focus-areas/event-diversity/time-inclusion-for-virtual-events.md
+++ b/focus-areas/event-diversity/time-inclusion-for-virtual-events.md
@@ -13,7 +13,7 @@ Global accessibility is vital due to the role it brings in choosing when an even
 *The usage and dissemination of health metrics may lead to privacy violations. Organizations may be exposed to risks. These risks may flow from compliance with the GDPR in the EU, with state law in the US, or with other law. There may also be contractual risks flowing from terms of service for data providers such as GitHub and GitLab. The usage of metrics must be examined for risk and potential data ethics problems. Please see [CHAOSS Data Ethics document](https://github.com/chaoss/community/blob/main/data-use-statement.md) for additional guidance.*
 
 
-Examples of Time Inclusion which can be implemented include:
+Examples of Time Inclusion for Virtual Events which can be implemented include:
 - Having the speaker do a pre-recording where the speaker is able to answer questions live in the chat
 - Doing a presentation within a certain time block for certain time zones
 - Preparing and sending a recording to be live within an hour
@@ -21,18 +21,18 @@ Examples of Time Inclusion which can be implemented include:
 
 ### Data Collection Strategies
 
-Survey attendees with Likert Scale [1-5] (Or Emoji Scale):
+Survey attendees with Likert Scale [1-x] (Or Emoji Scale):
 - The event keeps time zone differences in mind
 - The event caters to my needs related to differences in time
 - The event provides adequate recordings of the talks I care about
 - I was provided with adequate low-bandwidth options at the event
 
-Survey speakers with Likert Scale [1-5] (Or Emoji Scale):
+Survey speakers with Likert Scale [1-x] (Or Emoji Scale):
 - The time block selected for my presentation at the event is fair to me
 - I have, or will receive, a recording of my presentation for later viewing
 
 ## References
-[Medium Article](https://coonoor.medium.com/how-to-make-virtual-meetings-events-more-inclusive-de742ec0e672)
+- [How To Make Virtual Meetings & Events More Inclusive](https://coonoor.medium.com/how-to-make-virtual-meetings-events-more-inclusive-de742ec0e672)
 
 ## Contributors
 - Ruth Ikegah
@@ -42,3 +42,5 @@ Survey speakers with Likert Scale [1-5] (Or Emoji Scale):
 - Matt Cantu
 - Lauren Phipps
 - Yehui Wang
+
+***This metric was last reviewed on March 08, 2022 as part of 2022-04 release.***


### PR DESCRIPTION
Issues solved:
'Examples of Time Inclusion' should be 'Examples of Time Inclusion for Virtual Events'
Update the Likert Scale from [1-5] to [1-x]
Update the references to the actual title
Add date of last review

Issues unsolved:
How is 'Network bandwidth' part of the metric?
How is 'low bandwidth' part of the metric?
For survey of speakers, why is the second point important?

all issues from #433 