### PR TITLE
Update code-of-conduct-at-event.md

### DIFF
--- a/focus-areas/event-diversity/code-of-conduct-at-event.md
+++ b/focus-areas/event-diversity/code-of-conduct-at-event.md
@@ -13,7 +13,6 @@ An event with a code of conduct sends the signal that the organizers are willing
 - Event participants want to know that they will be safe at an event.
 
 ## Implementation
-*The usage and dissemination of health metrics may lead to privacy violations. Organizations may be exposed to risks. These risks may flow from compliance with the GDPR in the EU, with state law in the US, or with other law. There may also be contractual risks flowing from terms of service for data providers such as GitHub and GitLab. The usage of metrics must be examined for risk and potential data ethics problems. Please see [CHAOSS Data Ethics document](https://github.com/chaoss/community/blob/main/data-use-statement.md) for additional guidance.*
 
 ### Data Collection Strategies
 
@@ -56,5 +55,3 @@ An event with a code of conduct sends the signal that the organizers are willing
 * Justin Flory
 * Matt Germonprez
 * Kevin Lumbard
-
-***This metric was last reviewed on June 2nd 2022 as part of the recurring review process***


### PR DESCRIPTION
Signed-off-by: Matt Germonprez <germonprez@gmail.com>

Removing privacy statement in favor of including the statement as a new Wordpress module that can be more easily managed from a central document. Also removed the date of last review (if necessary) in favor of including a statement about how we regularly review documents that will also be included in the privacy statement model. This will assist with better central management of shared statements across all metrics.