### PR TITLE
Update board-council-diversity.md

### DIFF
--- a/focus-areas/governance/board-council-diversity.md
+++ b/focus-areas/governance/board-council-diversity.md
@@ -28,5 +28,3 @@ An open source contributor would often like to know that someone on the governin
 - https://www.linuxfoundation.org/about/diversity-inclusiveness/ 
 - (The Truth About Board Diversity)[https://www.cicf.org/2021/11/29/the-truth-about-board-diversity/]
 
-
-***This metric was last reviewed on July 20, 2022 as part of the metrics revision process.***


### PR DESCRIPTION
Signed-off-by: Matt Germonprez <germonprez@gmail.com>

Removing privacy statement in favor of including the statement as a new Wordpress module that can be more easily managed from a central document. Also removed the date of last review (if necessary) in favor of including a statement about how we regularly review documents that will also be included in the privacy statement model. This will assist with better central management of shared statements across all metrics.